### PR TITLE
Add workflow_dispatch inputs and PR triggers to IAC pipelines

### DIFF
--- a/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
@@ -6,7 +6,28 @@ on:
       - 'iac_modules/pulumi/**'
       - 'config/alicloud/**'
       - '.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml'
+  pull_request:
+    branches: [main]
   workflow_dispatch:
+    inputs:
+      deploy_action:
+        description: "Deployment action to execute"
+        type: choice
+        options:
+          - init
+          - magrate
+          - upgrade
+          - backup
+          - restore
+          - destroy
+        default: upgrade
+      deploy_dry_run:
+        description: "Run deployment steps in dry-run mode"
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
 
 env:
   PULUMI_CI: 'true'

--- a/.github/workflows/iac-pipeline-infrastructure-monitor-exporter.yml
+++ b/.github/workflows/iac-pipeline-infrastructure-monitor-exporter.yml
@@ -1,17 +1,27 @@
 name: Deploy Infrastructure Monitor Exporters
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
-    branches:
-      - main
     inputs:
       deploy_action:
-        description: 'Deployment action to perform'
-        required: false
+        description: "Deployment action to execute"
+        type: choice
+        options:
+          - init
+          - magrate
+          - upgrade
+          - backup
+          - restore
+          - destroy
         default: upgrade
       deploy_dry_run:
-        description: 'Whether to perform a dry-run'
-        required: false
+        description: "Run deployment steps in dry-run mode"
+        type: choice
+        options:
+          - 'true'
+          - 'false'
         default: 'true'
 
 jobs:

--- a/.github/workflows/iac-pipeline-infrastructure-monitor-server.yml
+++ b/.github/workflows/iac-pipeline-infrastructure-monitor-server.yml
@@ -4,13 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       deploy_action:
-        description: "Action to perform (upgrade, destroy, etc.)"
-        required: false
+        description: "Deployment action to execute"
+        type: choice
+        options:
+          - init
+          - magrate
+          - upgrade
+          - backup
+          - restore
+          - destroy
         default: upgrade
       deploy_dry_run:
-        description: "Run Ansible in check mode"
-        required: false
+        description: "Run deployment steps in dry-run mode"
+        type: choice
+        options:
+          - 'true'
+          - 'false'
         default: 'true'
+  pull_request:
+    branches: [main]
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- add pull request triggers to the Alicloud landing zone and infrastructure monitor workflows
- align manual dispatch inputs across workflows with consistent choices and dry-run default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da1333bc708332b639bd9752ef1ac0