### PR TITLE
Add configurable config_path to multi-cloud landing zone workflow

### DIFF
--- a/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
@@ -27,6 +27,11 @@ on:
           - 'true'
           - 'false'
         default: 'true'
+      config_path:
+        description: "Configuration directory path"
+        required: false
+        type: string
+        default: config/alicloud
   workflow_call:
     inputs:
       deploy_action:
@@ -37,6 +42,10 @@ on:
         required: false
         type: string
         default: 'true'
+      config_path:
+        required: false
+        type: string
+        default: config/alicloud
     secrets:
       ALICLOUD_ACCESS_KEY:
         required: true
@@ -49,7 +58,7 @@ on:
 
 env:
   PULUMI_CI: 'true'
-  CONFIG_PATH: config/alicloud
+  CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/alicloud' }}
   DEPLOY_ACTION: ${{ inputs.deploy_action || github.event.inputs.deploy_action || 'upgrade' }}
   DEPLOY_DRY_RUN: ${{ inputs.deploy_dry_run || github.event.inputs.deploy_dry_run || 'true' }}
 

--- a/.github/workflows/iac-pipeline-aws-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-aws-landingzone-baseline.yaml
@@ -27,6 +27,11 @@ on:
           - 'true'
           - 'false'
         default: 'true'
+      config_path:
+        description: "Configuration directory path"
+        required: false
+        type: string
+        default: config/aws-global
   workflow_call:
     inputs:
       deploy_action:
@@ -37,6 +42,10 @@ on:
         required: false
         type: string
         default: 'true'
+      config_path:
+        required: false
+        type: string
+        default: config/aws-global
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -51,7 +60,7 @@ on:
 
 env:
   PULUMI_CI: 'true'
-  CONFIG_PATH: config/aws-global
+  CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/aws-global' }}
   DEPLOY_ACTION: ${{ inputs.deploy_action || github.event.inputs.deploy_action || 'upgrade' }}
   DEPLOY_DRY_RUN: ${{ inputs.deploy_dry_run || github.event.inputs.deploy_dry_run || 'true' }}
 

--- a/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
@@ -28,13 +28,17 @@ jobs:
       matrix:
         include:
           - provider: Alicloud
+            config: config/alicloud/
             workflow: iac-pipeline-alicloud-landingzone-baseline.yaml
           - provider: AWS
+            config: config/aws-global/
             workflow: iac-pipeline-aws-landingzone-baseline.yaml
           - provider: Vultr
+            config: config/vultr/
             workflow: iac-pipeline-vultr-landingzone-baseline.yaml
     uses: ./.github/workflows/${{ matrix.workflow }}
     with:
       deploy_action: ${{ inputs.deploy_action }}
       deploy_dry_run: ${{ inputs.deploy_dry_run }}
+      config_path: ${{ matrix.config }}
     secrets: inherit

--- a/.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
@@ -27,6 +27,11 @@ on:
           - 'true'
           - 'false'
         default: 'true'
+      config_path:
+        description: "Configuration directory path"
+        required: false
+        type: string
+        default: config/vultr
   workflow_call:
     inputs:
       deploy_action:
@@ -37,6 +42,10 @@ on:
         required: false
         type: string
         default: 'true'
+      config_path:
+        required: false
+        type: string
+        default: config/vultr
     secrets:
       VULTR_API_KEY:
         required: true
@@ -45,7 +54,7 @@ on:
 
 env:
   PULUMI_CI: 'true'
-  CONFIG_PATH: config/vultr
+  CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/vultr' }}
   DEPLOY_ACTION: ${{ inputs.deploy_action || github.event.inputs.deploy_action || 'upgrade' }}
   DEPLOY_DRY_RUN: ${{ inputs.deploy_dry_run || github.event.inputs.deploy_dry_run || 'true' }}
 


### PR DESCRIPTION
## Summary
- add provider configuration paths to the multi-cloud baseline matrix and pass them into the reusable workflows
- allow the Alicloud, AWS, and Vultr baseline workflows to accept an optional config_path input and use it when supplied

## Testing
- not run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68daa091b10c83329e6c1b765585f4fb