### PR TITLE
Add multi-cloud option to Pulumi CLI wrapper

### DIFF
--- a/iac_modules/pulumi/README.md
+++ b/iac_modules/pulumi/README.md
@@ -96,7 +96,7 @@ python cli.py <命令>
 python cli.py init --stack dev --backend s3://my-state-bucket/dev
 ```
 
-`--credentials` 可用于指定其他凭据文件路径，默认读取 `~/.iac/credentials`。
+`--credentials` 可用于指定其他凭据文件路径，默认读取 `~/.iac/credentials`。若需要在多云配置之间快速切换，可使用 `--cloud {alicloud,aws,vultr}` 参数自动选择 `config/<cloud>` 目录并设置 `IAC_CLOUD` 环境变量。
 
 支持的命令如下：
 


### PR DESCRIPTION
## Summary
- add a --cloud flag to the Pulumi helper CLI to select supported providers and automatically set default config directories
- ensure CLI help output renders multi-line guidance and propagates the chosen cloud to the runtime environment
- document the new switch in the Pulumi module README for easier multi-cloud workflows

## Testing
- python3 cli.py init --help

------
https://chatgpt.com/codex/tasks/task_e_68db9da0914483328957f6956a254b86