### PR TITLE
Add validation and delivery stages to landing zone workflows

### DIFF
--- a/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
@@ -88,9 +88,18 @@ jobs:
           ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
+  validation:
+    name: Validate Alicloud baseline readiness
+    needs: preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "Alicloud" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
+
   apply:
     name: Apply to Alicloud production stack
-    needs: preview
+    needs: validation
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -86,9 +86,18 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
+  validation:
+    name: Validate AWS baseline readiness
+    needs: preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "AWS" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
+
   apply:
     name: Apply AWS baseline to production
-    needs: preview
+    needs: validation
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
@@ -24,8 +24,8 @@ on:
         default: 'true'
 
 jobs:
-  run-baseline:
-    name: Trigger baseline workflow (${{ matrix.provider }})
+  preview:
+    name: Preview baseline workflow (${{ matrix.provider }})
     strategy:
       matrix:
         include:
@@ -48,8 +48,31 @@ jobs:
       config_path: ${{ matrix.config }}
     secrets: inherit
 
-  pulumi-up:
-    name: Pulumi up (${{ matrix.provider }})
+  validation:
+    name: Validate baseline readiness (${{ matrix.provider }})
+    needs: preview
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - provider: Alicloud
+            config: config/alicloud/
+            pulumi_dir: iac_modules/pulumi
+          - provider: AWS
+            config: config/aws-global/
+            pulumi_dir: iac_modules/pulumi
+          - provider: Vultr
+            config: config/vultr/
+            pulumi_dir: iac_modules/pulumi
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "${{ matrix.provider }}" "${{ matrix.config }}" "${{ matrix.pulumi_dir }}"
+
+  apply:
+    name: Apply baseline via Pulumi (${{ matrix.provider }})
+    needs: validation
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,7 +87,7 @@ jobs:
             stack: svc-design/vultr-lz-global-dev
             region: global
     steps:
-      - name: Pulumi up
+      - name: Apply baseline via Pulumi
         run: pulumi up --stack ${{ matrix.stack }} --yes
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -73,3 +96,14 @@ jobs:
           ALICLOUD_ACCESS_KEY: ${{ secrets.ALICLOUD_AK }}
           ALICLOUD_SECRET_KEY: ${{ secrets.ALICLOUD_SK }}
           VULTR_API_KEY: ${{ secrets.VULTR_API_KEY }}
+
+  delivery:
+    name: Deliver baseline rollout notifications
+    needs: apply
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Notify stakeholders
+        run: scripts/notifications/notify-baseline-delivery.sh
+

--- a/.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
@@ -118,9 +118,27 @@ jobs:
           VULTR_API_KEY: ${{ secrets.VULTR_API_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
+  validation:
+    name: Validate Vultr baseline readiness
+    needs: preview
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_action != 'init') ||
+        (github.event_name == 'workflow_call' && inputs.deploy_action != 'init') ||
+        (github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call')
+      }}
+    runs-on: ubuntu-latest
+    env:
+      PULUMI_CI: 'true'
+      CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/vultr' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "Vultr" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
+
   apply:
     name: Apply to production stack
-    needs: preview
+    needs: validation
     if: >-
       ${{
         (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_action != 'init') ||

--- a/scripts/notifications/notify-baseline-delivery.sh
+++ b/scripts/notifications/notify-baseline-delivery.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+channels=${DELIVERY_CHANNELS:-"email,im,webhook"}
+summary="Baseline rollout completed for multi-cloud landing zones."
+
+printf 'Delivery Summary: %s\n' "$summary"
+printf 'Notifying channels: %s\n' "$channels"
+printf 'Workflow run: %s\n' "$run_url"

--- a/scripts/validation/validate-baseline.sh
+++ b/scripts/validation/validate-baseline.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+provider=${1:-}
+config_path=${2:-}
+pulumi_dir=${3:-iac_modules/pulumi}
+
+if [[ -z "$provider" || -z "$config_path" ]]; then
+  echo "Usage: $0 <provider> <config_path> [pulumi_dir]" >&2
+  exit 2
+fi
+
+if [[ ! -d "$config_path" ]]; then
+  echo "[${provider}] Configuration path '$config_path' does not exist" >&2
+  exit 1
+fi
+
+if ! find "$config_path" -type f \( -name '*.yaml' -o -name '*.yml' -o -name '*.json' \) -mindepth 1 -print -quit >/dev/null; then
+  echo "[${provider}] Expected configuration files (yaml/json) are missing in '$config_path'" >&2
+  exit 1
+fi
+
+if [[ ! -d "$pulumi_dir" ]]; then
+  echo "[${provider}] Pulumi directory '$pulumi_dir' does not exist" >&2
+  exit 1
+fi
+
+if ! find "$pulumi_dir" -name 'Pulumi.yaml' -print -quit >/dev/null; then
+  echo "[${provider}] Pulumi project definition (Pulumi.yaml) not found under '$pulumi_dir'" >&2
+  exit 1
+fi
+
+if [[ -n "${DEPLOY_DRY_RUN:-}" ]]; then
+  echo "[${provider}] Dry-run flag: ${DEPLOY_DRY_RUN}";
+fi
+
+echo "[${provider}] Baseline validation checks completed successfully"


### PR DESCRIPTION
## Summary
- rename multi-cloud workflow stages and add validation and delivery jobs for baseline deployments
- introduce shared validation script and wire it into Alicloud, AWS, Vultr, and multi-cloud pipelines
- add notification script for final delivery step in the multi-cloud workflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfa6ac10208332876c3bd5c7cad203