### PR TITLE
Fix multi-cloud landing zone workflow orchestration

### DIFF
--- a/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
@@ -88,19 +88,10 @@ jobs:
           ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
-  validation:
-    name: Validate Alicloud baseline readiness
-    needs: preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run baseline validation checks
-        run: scripts/validation/validate-baseline.sh "Alicloud" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
-
   apply:
     name: Apply to Alicloud production stack
-    needs: validation
-    if: github.ref == 'refs/heads/main'
+    needs: preview
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -122,3 +113,21 @@ jobs:
           ALICLOUD_SECRET_KEY: ${{ secrets.ALICLOUD_SECRET_KEY }}
           ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+  validation:
+    name: Validate Alicloud baseline readiness
+    needs: apply
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "Alicloud" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
+
+  delivery:
+    name: Deliver Alicloud baseline rollout notifications
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify stakeholders
+        run: scripts/notifications/notify-baseline-delivery.sh

--- a/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -29,10 +29,42 @@ on:
           - 'true'
           - 'false'
         default: 'true'
+      config_path:
+        description: "Configuration directory path"
+        required: false
+        type: string
+        default: config/aws-global
+  workflow_call:
+    inputs:
+      deploy_action:
+        required: false
+        type: string
+        default: upgrade
+      deploy_dry_run:
+        required: false
+        type: string
+        default: 'true'
+      config_path:
+        required: false
+        type: string
+        default: config/aws-global
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_SESSION_TOKEN:
+        required: false
+      AWS_REGION:
+        required: true
+      PULUMI_ACCESS_TOKEN:
+        required: true
 
 env:
   PULUMI_CI: 'true'
-  CONFIG_PATH: config/aws-global
+  CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/aws-global' }}
+  DEPLOY_ACTION: ${{ inputs.deploy_action || github.event.inputs.deploy_action || 'upgrade' }}
+  DEPLOY_DRY_RUN: ${{ inputs.deploy_dry_run || github.event.inputs.deploy_dry_run || 'true' }}
 
 jobs:
   preview:
@@ -86,19 +118,10 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
-  validation:
-    name: Validate AWS baseline readiness
-    needs: preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run baseline validation checks
-        run: scripts/validation/validate-baseline.sh "AWS" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
-
   apply:
     name: Apply AWS baseline to production
-    needs: validation
-    if: github.ref == 'refs/heads/main'
+    needs: preview
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -145,3 +168,21 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+  validation:
+    name: Validate AWS baseline readiness
+    needs: apply
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "AWS" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
+
+  delivery:
+    name: Deliver AWS baseline rollout notifications
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify stakeholders
+        run: scripts/notifications/notify-baseline-delivery.sh

--- a/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
@@ -35,7 +35,7 @@ jobs:
             action: output
           - provider: AWS
             config: config/aws-global/
-            workflow: iac-pipeline-aws-landingzone-baseline.yaml
+            workflow: iac-pipeline-aws-global-landingzone-baseline.yaml
             action: output
           - provider: Vultr
             config: config/vultr/
@@ -43,14 +43,42 @@ jobs:
             action: output
     uses: ./.github/workflows/${{ matrix.workflow }}
     with:
-      deploy_action: ${{ matrix.action || inputs.deploy_action }}
+      deploy_action: ${{ matrix.action != '' && matrix.action || inputs.deploy_action }}
       deploy_dry_run: ${{ inputs.deploy_dry_run }}
       config_path: ${{ matrix.config }}
     secrets: inherit
 
+  apply:
+    name: Apply baseline via Pulumi (${{ matrix.provider }})
+    needs: preview
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - provider: AWS
+            stack: svc-design/aws-lz-us-east-1-dev
+            region: us-east-1
+          - provider: Alicloud
+            stack: svc-design/alicloud-lz-cn-hangzhou-dev
+            region: cn-hangzhou
+          - provider: Vultr
+            stack: svc-design/vultr-lz-global-dev
+            region: global
+    steps:
+      - name: Apply baseline via Pulumi
+        run: pulumi up --stack ${{ matrix.stack }} --yes
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          ALICLOUD_ACCESS_KEY: ${{ secrets.ALICLOUD_ACCESS_KEY }}
+          ALICLOUD_SECRET_KEY: ${{ secrets.ALICLOUD_SECRET_KEY }}
+          VULTR_API_KEY: ${{ secrets.VULTR_API_KEY }}
+
   validation:
     name: Validate baseline readiness (${{ matrix.provider }})
-    needs: preview
+    needs: apply
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -70,36 +98,9 @@ jobs:
       - name: Run baseline validation checks
         run: scripts/validation/validate-baseline.sh "${{ matrix.provider }}" "${{ matrix.config }}" "${{ matrix.pulumi_dir }}"
 
-  apply:
-    name: Apply baseline via Pulumi (${{ matrix.provider }})
-    needs: validation
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - provider: AWS
-            stack: svc-design/aws-lz-us-east-1-dev
-            region: us-east-1
-          - provider: Alicloud
-            stack: svc-design/alicloud-lz-cn-hangzhou-dev
-            region: cn-hangzhou
-          - provider: Vultr
-            stack: svc-design/vultr-lz-global-dev
-            region: global
-    steps:
-      - name: Apply baseline via Pulumi
-        run: pulumi up --stack ${{ matrix.stack }} --yes
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_AK }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SK }}
-          ALICLOUD_ACCESS_KEY: ${{ secrets.ALICLOUD_AK }}
-          ALICLOUD_SECRET_KEY: ${{ secrets.ALICLOUD_SK }}
-          VULTR_API_KEY: ${{ secrets.VULTR_API_KEY }}
-
   delivery:
     name: Deliver baseline rollout notifications
-    needs: apply
+    needs: validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
@@ -118,27 +118,9 @@ jobs:
           VULTR_API_KEY: ${{ secrets.VULTR_API_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
-  validation:
-    name: Validate Vultr baseline readiness
-    needs: preview
-    if: >-
-      ${{
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_action != 'init') ||
-        (github.event_name == 'workflow_call' && inputs.deploy_action != 'init') ||
-        (github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call')
-      }}
-    runs-on: ubuntu-latest
-    env:
-      PULUMI_CI: 'true'
-      CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/vultr' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run baseline validation checks
-        run: scripts/validation/validate-baseline.sh "Vultr" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
-
   apply:
     name: Apply to production stack
-    needs: validation
+    needs: preview
     if: >-
       ${{
         (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_action != 'init') ||
@@ -175,3 +157,36 @@ jobs:
         env:
           VULTR_API_KEY: ${{ secrets.VULTR_API_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+  validation:
+    name: Validate Vultr baseline readiness
+    needs: apply
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_action != 'init') ||
+        (github.event_name == 'workflow_call' && inputs.deploy_action != 'init') ||
+        (github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call')
+      }}
+    runs-on: ubuntu-latest
+    env:
+      PULUMI_CI: 'true'
+      CONFIG_PATH: ${{ inputs.config_path || github.event.inputs.config_path || 'config/vultr' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run baseline validation checks
+        run: scripts/validation/validate-baseline.sh "Vultr" "${{ env.CONFIG_PATH }}" "iac_modules/pulumi"
+
+  delivery:
+    name: Deliver Vultr baseline rollout notifications
+    needs: validation
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_action != 'init') ||
+        (github.event_name == 'workflow_call' && inputs.deploy_action != 'init') ||
+        (github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call')
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Notify stakeholders
+        run: scripts/notifications/notify-baseline-delivery.sh


### PR DESCRIPTION
## Summary
- update the multi-cloud landing zone workflow to call provider pipelines with the new preview -> apply -> validation -> delivery stage order and consistent secrets
- expose the Alicloud, AWS, and Vultr landing zone workflows as reusable workflow_call entries while preserving standalone dispatch behaviour
- add delivery notifications and post-apply validation gates to the provider pipelines for orchestrated rollouts

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dfac1a46108332b28baa0212835bca