### PR TITLE
Fix preview job reuse in multi-cloud baseline workflow

### DIFF
--- a/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-multi-cloud-landingzone-baseline.yaml
@@ -24,33 +24,39 @@ on:
         default: 'true'
 
 jobs:
-  preview:
-    name: Preview baseline workflow (${{ matrix.provider }})
-    strategy:
-      matrix:
-        include:
-          - provider: Alicloud
-            config: config/alicloud/
-            workflow: iac-pipeline-alicloud-landingzone-baseline.yaml
-            action: output
-          - provider: AWS
-            config: config/aws-global/
-            workflow: iac-pipeline-aws-global-landingzone-baseline.yaml
-            action: output
-          - provider: Vultr
-            config: config/vultr/
-            workflow: iac-pipeline-vultr-landingzone-baseline.yaml
-            action: output
-    uses: ./.github/workflows/${{ matrix.workflow }}
+  preview_alicloud:
+    name: Preview baseline workflow (Alicloud)
+    uses: ./.github/workflows/iac-pipeline-alicloud-landingzone-baseline.yaml
     with:
-      deploy_action: ${{ matrix.action != '' && matrix.action || inputs.deploy_action }}
+      deploy_action: output
       deploy_dry_run: ${{ inputs.deploy_dry_run }}
-      config_path: ${{ matrix.config }}
+      config_path: config/alicloud/
+    secrets: inherit
+
+  preview_aws:
+    name: Preview baseline workflow (AWS)
+    uses: ./.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
+    with:
+      deploy_action: output
+      deploy_dry_run: ${{ inputs.deploy_dry_run }}
+      config_path: config/aws-global/
+    secrets: inherit
+
+  preview_vultr:
+    name: Preview baseline workflow (Vultr)
+    uses: ./.github/workflows/iac-pipeline-vultr-landingzone-baseline.yaml
+    with:
+      deploy_action: output
+      deploy_dry_run: ${{ inputs.deploy_dry_run }}
+      config_path: config/vultr/
     secrets: inherit
 
   apply:
     name: Apply baseline via Pulumi (${{ matrix.provider }})
-    needs: preview
+    needs:
+      - preview_alicloud
+      - preview_aws
+      - preview_vultr
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- replace the reusable preview job matrix with discrete jobs for Alicloud, AWS, and Vultr
- update downstream dependencies to wait for all preview jobs before continuing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb22710a08332abaac5ad445ac9f5