### PR TITLE
Add service guardrails for landing zone

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone/main.tf
@@ -3,13 +3,96 @@ locals {
   mfa_policy        = var.enable_mfa_enforce      ? "deny-no-mfa.json"        : null
   console_policy    = var.console_mode == "readonly" ? "deny-console-write.json" : null
   risp_policy       = var.enable_risp_controls    ? "deny-ri-sp.json"         : null
+  sso_policy        = var.enable_identity_center_block ? "deny-sso-and-saml.json" : null
+
+  service_allow_list = distinct(concat([
+    "autoscaling:*",
+    "cloudformation:*",
+    "cloudtrail:*",
+    "cloudwatch:*",
+    "ec2:*",
+    "ecr:*",
+    "ecs:*",
+    "eks:*",
+    "elasticloadbalancing:*",
+    "iam:*",
+    "kms:*",
+    "logs:*",
+    "organizations:*",
+    "rds:*",
+    "route53:*",
+    "s3:*",
+    "ses:*",
+    "sns:*",
+    "sqs:*",
+    "ssm:*",
+    "sts:*"
+  ], var.service_allow_list))
+
+  service_deny_list = distinct(concat([
+    "aoss:*",
+    "apigateway:*",
+    "appflow:*",
+    "appintegrations:*",
+    "appstream:*",
+    "appsync:*",
+    "chime:*",
+    "cloudsearch:*",
+    "cognito-identity:*",
+    "cognito-idp:*",
+    "cognito-sync:*",
+    "connect:*",
+    "dynamodb:*",
+    "eventbridge:*",
+    "finspace:*",
+    "grafana:*",
+    "iot:*",
+    "ivschat:*",
+    "kafka:*",
+    "kinesis:*",
+    "lambda:*",
+    "license-manager-user-subscriptions:*",
+    "lightsail:*",
+    "mediaconnect:*",
+    "pinpoint:*",
+    "quicksight:*",
+    "redshift-serverless:*",
+    "rekognition:*",
+    "sagemaker:*",
+    "sesv2:*",
+    "stepfunctions:*",
+    "timestream:*",
+    "transcribe:*",
+    "translate:*",
+    "workmail:*",
+    "workspaces:*"
+  ], var.service_deny_list))
 
   policies = compact([
     local.root_policy,
     local.mfa_policy,
     local.console_policy,
-    local.risp_policy
+    local.risp_policy,
+    local.sso_policy
   ])
+}
+
+data "aws_iam_policy_document" "service_controls" {
+  count = var.enable_service_guardrails ? 1 : 0
+
+  statement {
+    sid        = "DenyActionsOutsideAllowList"
+    effect     = "Deny"
+    not_action = local.service_allow_list
+    resource   = "*"
+  }
+
+  statement {
+    sid     = "DenyBlacklistedServices"
+    effect  = "Deny"
+    action  = local.service_deny_list
+    resource = "*"
+  }
 }
 
 #
@@ -37,4 +120,18 @@ resource "aws_iam_group_policy_attachment" "attach" {
 
   group      = aws_iam_group.baseline.name
   policy_arn = each.value.arn
+}
+
+resource "aws_iam_policy" "service_controls" {
+  count = var.enable_service_guardrails ? 1 : 0
+
+  name   = "landingzone-service-guardrails"
+  policy = data.aws_iam_policy_document.service_controls[0].json
+}
+
+resource "aws_iam_group_policy_attachment" "service_controls" {
+  count = var.enable_service_guardrails ? 1 : 0
+
+  group      = aws_iam_group.baseline.name
+  policy_arn = aws_iam_policy.service_controls[0].arn
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone/policies/deny-sso-and-saml.json
+++ b/iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone/policies/deny-sso-and-saml.json
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyIAMIdentityCenterAndIdentityStore",
+      "Effect": "Deny",
+      "Action": [
+        "sso:*",
+        "sso-directory:*",
+        "sso-oauth:*",
+        "identitystore:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenySAMLFederation",
+      "Effect": "Deny",
+      "Action": "sts:AssumeRoleWithSAML",
+      "Resource": "*"
+    }
+  ]
+}

--- a/iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone/variables.tf
@@ -25,3 +25,25 @@ variable "enable_mfa_enforce" {
   type    = bool
   default = true
 }
+
+variable "enable_identity_center_block" {
+  type    = bool
+  default = true
+}
+
+variable "enable_service_guardrails" {
+  type    = bool
+  default = true
+}
+
+variable "service_allow_list" {
+  type        = list(string)
+  default     = []
+  description = "Additional service action patterns to allow when service guardrails are enabled."
+}
+
+variable "service_deny_list" {
+  type        = list(string)
+  default     = []
+  description = "Additional service action patterns to deny when service guardrails are enabled."
+}


### PR DESCRIPTION
## Summary
- add a service guardrail IAM policy that allow-lists core IaaS/PaaS services and blocks SaaS/serverless usage via a blacklist
- make the service allow/deny lists configurable and enable the guardrail by default in the landing zone baseline group

## Testing
- terraform fmt iac-template/terraform-hcl-standard/aws-cloud/modules/landingzone *(fails: terraform not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693510e1d9d08332a6f2de5dfb8d25e5)