### PR TITLE
Add shared bootstrap config and update workflow

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-global-bootstrap.yaml
@@ -12,16 +12,12 @@ on:
     inputs:
       deploy_action:
         type: choice
-        options: [init, plan, apply, destroy]
+        options: [plan, apply, destroy]
         default: plan
-      deploy_dry_run:
-        type: choice
-        options: ['true', 'false']
-        default: 'true'
 
 env:
   TF_WORKDIR: iac-template/terraform-hcl-standard/aws-cloud
-  DRY_RUN: ${{ github.event.inputs.deploy_dry_run || 'true' }}
+  DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
 
 jobs:
   bootstrap:
@@ -51,33 +47,37 @@ jobs:
         run: make init
 
       - name: Plan
-        if: env.DRY_RUN == 'true'
+        if: env.DEPLOY_ACTION == 'plan'
         working-directory: ${{ env.TF_WORKDIR }}/${{ matrix.target }}
         run: make plan
 
       - name: Apply
-        if: env.DRY_RUN == 'false'
+        if: env.DEPLOY_ACTION == 'apply'
         working-directory: ${{ env.TF_WORKDIR }}/${{ matrix.target }}
         run: make apply
 
+      - name: Destroy
+        if: env.DEPLOY_ACTION == 'destroy'
+        working-directory: ${{ env.TF_WORKDIR }}/${{ matrix.target }}
+        run: make destroy
+
       - name: Save Outputs
-        if: env.DRY_RUN == 'false'
+        if: env.DEPLOY_ACTION == 'apply'
         working-directory: ${{ env.TF_WORKDIR }}/${{ matrix.target }}
         run: terraform output -json > ../../outputs_${{ matrix.target }}.json
 
       - uses: actions/upload-artifact@v4
-        if: env.DRY_RUN == 'false'
+        if: env.DEPLOY_ACTION == 'apply'
         with:
           name: outputs-${{ matrix.target }}
-          path: iac-template/terraform-standard/outputs_${{ matrix.target }}.json
+          path: iac-template/terraform-hcl-standard/aws-cloud/outputs_${{ matrix.target }}.json
 
   aggregate:
     name: "Aggregate Bootstrap Outputs"
     runs-on: ubuntu-latest
     needs: bootstrap
 
-    # ❗ Job-level 不能用 env.DRY_RUN，要用 github.event.inputs.*
-    if: ${{ github.event.inputs.deploy_dry_run == 'false' }}
+    if: ${{ github.event.inputs.deploy_action == 'apply' }}
 
     steps:
       - uses: actions/download-artifact@v4

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/Makefile
@@ -1,16 +1,20 @@
+table_name ?=
+region ?=
+
+TF_VARS := $(if $(table_name),-var="table_name=$(table_name)") $(if $(region),-var="region=$(region)")
+
 init:
 	terraform init --upgrade
 	terraform init -migrate-state
 
 apply: init
-	terraform apply \
-		-var="table_name=svc-plus-iac-state-dynamodb-lock" \
-		-var="region=ap-northeast-1" \
-		-auto-approve
+	terraform apply $(TF_VARS) -auto-approve
+
 plan: init
-	terraform plan -var="table_name=svc-plus-iac-state-dynamodb-lock" -var="region=ap-northeast-1"
+	terraform plan $(TF_VARS)
+
 output: init
 	terraform output
-destroy: init
-	terraform destroy -var="table_name=svc-plus-iac-state-dynamodb-lock" -var="region=ap-northeast-1"
 
+destroy: init
+	terraform destroy $(TF_VARS)

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  bootstrap = yamldecode(file("${path.root}/../config/accounts/bootstrap.yaml"))
+
+  dynamodb_table_name = coalesce(var.table_name, local.bootstrap.state.dynamodb_table_name)
+  region              = coalesce(var.region, local.bootstrap.region)
+  environment         = try(local.bootstrap.environment, "bootstrap")
+  tags                = try(local.bootstrap.tags, {})
+}

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/main.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "terraform_locks" {
-  name         = var.table_name
+  name         = local.dynamodb_table_name
   billing_mode = "PAY_PER_REQUEST"
 
   hash_key = "LockID"
@@ -9,8 +9,11 @@ resource "aws_dynamodb_table" "terraform_locks" {
     type = "S"
   }
 
-  tags = {
-    Name        = var.table_name
-    Environment = "bootstrap"
-  }
+  tags = merge(
+    {
+      Name        = local.dynamodb_table_name
+      Environment = local.environment
+    },
+    local.tags
+  )
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/provider.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/provider.tf
@@ -10,5 +10,5 @@ terraform {
 }
 
 provider "aws" {
-  region = var.region
+  region = local.region
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/variables.tf
@@ -1,9 +1,11 @@
 variable "table_name" {
   description = "DynamoDB table name for Terraform state lock"
   type        = string
+  default     = null
 }
 
 variable "region" {
   description = "AWS region"
   type        = string
+  default     = null
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/Makefile
@@ -1,29 +1,19 @@
-account_name ?= dev
-region ?= ap-northeast-1
-role_name ?= TerraformDeployRole-Dev
-terraform_user_name ?= sit-ci-runner
+account_name ?=
+region ?=
+role_name ?=
+	terraform_user_name ?=
+
+TF_VARS := $(if $(account_name),-var="account_name=$(account_name)") $(if $(region),-var="region=$(region)") $(if $(role_name),-var="role_name=$(role_name)") $(if $(terraform_user_name),-var="terraform_user_name=$(terraform_user_name)")
 
 init:
 	terraform init --upgrade
 	terraform init -migrate-state
 apply: init
-	terraform apply -auto-approve \
-		-var="account_name=$(account_name)" \
-		-var="region=$(region)" \
-		-var="role_name=$(role_name)" \
-		-var="terraform_user_name=$(terraform_user_name)"
+	terraform apply -auto-approve $(TF_VARS)
 	terraform output
 plan: init
-	terraform plan \
-		-var="account_name=$(account_name)" \
-		-var="region=$(region)" \
-		-var="role_name=$(role_name)" \
-		-var="terraform_user_name=$(terraform_user_name)"
+	terraform plan $(TF_VARS)
 output: init
 	terraform output
 destroy: init
-	terraform destroy \
-		-var="account_name=$(account_name)" \
-		-var="region=$(region)" \
-		-var="role_name=$(role_name)" \
-		-var="terraform_user_name=$(terraform_user_name)"
+	terraform destroy $(TF_VARS)

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  bootstrap = yamldecode(file("${path.root}/../config/accounts/bootstrap.yaml"))
+
+  config_account_name     = coalesce(var.account_name, local.bootstrap.account_name)
+  config_region           = coalesce(var.region, local.bootstrap.region)
+  config_role_name        = coalesce(var.role_name, local.bootstrap.iam.role_name)
+  config_terraform_user   = coalesce(var.terraform_user_name, local.bootstrap.iam.terraform_user_name)
+  environment             = coalesce(try(local.bootstrap.environment, null), try(local.bootstrap.iam.environment, null), "bootstrap")
+  extra_tags              = try(local.bootstrap.tags, {})
+}
+
+locals {
+  account = yamldecode(
+    file("${path.root}/../config/accounts/${local.config_account_name}.yaml")
+  )
+}

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/provider.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/provider.tf
@@ -10,5 +10,5 @@ terraform {
 }
 
 provider "aws" {
-  region = var.region
+  region = local.config_region
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/variables.tf
@@ -1,19 +1,23 @@
 variable "region" {
   description = "AWS region"
   type        = string
+  default     = null
 }
 
 variable "account_name" {
   type        = string
   description = "Which account configuration to load (e.g., dev)"
+  default     = null
 }
 
 variable "role_name" {
   type        = string
   description = "IAM role name to create (e.g., TerraformDeployRole-Dev)"
+  default     = null
 }
 
 variable "terraform_user_name" {
   type        = string
   description = "IAM username for Terraform IAC runner"
+  default     = null
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/Makefile
@@ -1,15 +1,21 @@
+bucket_name ?=
+region ?=
+
+TF_VARS := $(if $(bucket_name),-var="bucket_name=$(bucket_name)") $(if $(region),-var="region=$(region)")
+
 init:
 	terraform init --upgrade
 	terraform init -migrate-state
 
 apply: init
-	terraform apply -var="bucket_name=svc-plus-iac-state" -var=region=ap-northeast-1 -auto-approve
+	terraform apply $(TF_VARS) -auto-approve
 	terraform output
 
 plan: init
-	terraform plan -var="bucket_name=svc-plus-iac-state" -var=region=ap-northeast-1
+	terraform plan $(TF_VARS)
 
 output: init
 	terraform output
+
 destroy: init
-	terraform destroy -var="bucket_name=svc-plus-iac-state" -var=region=ap-northeast-1
+	terraform destroy $(TF_VARS)

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  bootstrap = yamldecode(file("${path.root}/../config/accounts/bootstrap.yaml"))
+
+  bucket_name = coalesce(var.bucket_name, local.bootstrap.state.bucket_name)
+  region      = coalesce(var.region, local.bootstrap.region)
+  environment = try(local.bootstrap.environment, "bootstrap")
+  tags        = try(local.bootstrap.tags, {})
+}

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "state" {
-  bucket = var.bucket_name
+  bucket = local.bucket_name
 }
 
 resource "aws_s3_bucket_versioning" "versioning" {
@@ -18,4 +18,16 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
       sse_algorithm = "AES256"
     }
   }
+}
+
+resource "aws_s3_bucket_tagging" "default" {
+  bucket = aws_s3_bucket.state.id
+
+  tag_set = [for k, v in merge({
+    Name        = local.bucket_name
+    Environment = local.environment
+  }, local.tags) : {
+    key   = k
+    value = v
+  }]
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/provider.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/provider.tf
@@ -10,5 +10,5 @@ terraform {
 }
 
 provider "aws" {
-  region = var.region
+  region = local.region
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/variables.tf
@@ -1,9 +1,11 @@
 variable "bucket_name" {
   description = "S3 bucket name for Terraform state"
   type        = string
+  default     = null
 }
 
 variable "region" {
   description = "AWS region"
   type        = string
+  default     = null
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml
+++ b/iac-template/terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml
@@ -1,0 +1,16 @@
+region: ap-northeast-1
+environment: bootstrap
+
+account_name: dev
+
+state:
+  bucket_name: svc-plus-iac-state
+  dynamodb_table_name: svc-plus-iac-state-dynamodb-lock
+
+iam:
+  role_name: TerraformDeployRole-Dev
+  terraform_user_name: sit-ci-runner
+
+tags:
+  Owner: Platform
+  Project: modern-container-app


### PR DESCRIPTION
## Summary
- add a shared bootstrap account configuration file and load it across the bootstrap modules
- update bootstrap Makefiles to use config defaults while allowing optional overrides
- adjust the bootstrap workflow to support plan/apply/destroy without backend artifacts

## Testing
- not run (terraform CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693686a815548332bc89ba452da09217)