### PR TITLE
Handle missing account config for bootstrap IAM

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/Makefile
@@ -1,7 +1,7 @@
 account_name ?=
 region ?=
 role_name ?=
-	terraform_user_name ?=
+terraform_user_name ?=
 
 TF_VARS := $(if $(account_name),-var="account_name=$(account_name)") $(if $(region),-var="region=$(region)") $(if $(role_name),-var="role_name=$(role_name)") $(if $(terraform_user_name),-var="terraform_user_name=$(terraform_user_name)")
 

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/locals.tf
@@ -10,7 +10,10 @@ locals {
 }
 
 locals {
-  account = yamldecode(
-    file("${path.root}/../config/accounts/${local.config_account_name}.yaml")
-  )
+  account_file_path = "${path.root}/../config/accounts/${local.config_account_name}.yaml"
+  account = fileexists(local.account_file_path) ? yamldecode(file(local.account_file_path)) : {
+    account_id  = local.bootstrap.account_id
+    environment = local.environment
+    tags        = local.extra_tags
+  }
 }


### PR DESCRIPTION
## Summary
- fall back to bootstrap account settings when a dedicated account config file is absent
- normalize the bootstrap IAM Makefile variable declaration

## Testing
- Not run (terraform CLI not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369aaf1e648332b43bd7ffe10633ea)