### PR TITLE
Update S3 bucket tagging for AWS provider 5

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/main.tf
@@ -1,5 +1,13 @@
 resource "aws_s3_bucket" "state" {
   bucket = local.bucket_name
+
+  tags = merge(
+    {
+      Name        = local.bucket_name
+      Environment = local.environment
+    },
+    local.tags,
+  )
 }
 
 resource "aws_s3_bucket_versioning" "versioning" {
@@ -18,16 +26,4 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
       sse_algorithm = "AES256"
     }
   }
-}
-
-resource "aws_s3_bucket_tagging" "default" {
-  bucket = aws_s3_bucket.state.id
-
-  tag_set = [for k, v in merge({
-    Name        = local.bucket_name
-    Environment = local.environment
-  }, local.tags) : {
-    key   = k
-    value = v
-  }]
 }


### PR DESCRIPTION
## Summary
- replace the removed `aws_s3_bucket_tagging` resource by defining tags directly on the S3 bucket
- retain versioning and encryption configurations for the state bucket

## Testing
- Not run (terraform CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369de76f6c833287184a8e6e4111fd)