### PR TITLE
Use AWS CLI for bootstrap destroy actions

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-global-bootstrap.yaml
@@ -65,7 +65,7 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Load bootstrap config for destroy
-        if: matrix.target == 'bootstrap-s3' && env.DEPLOY_ACTION == 'destroy'
+        if: env.DEPLOY_ACTION == 'destroy'
         run: |
           python -m pip install --quiet pyyaml
           python - <<'PY'
@@ -78,15 +78,15 @@ jobs:
 
           env_path = Path(os.environ["GITHUB_ENV"])
           current_env = env_path.read_text() if env_path.exists() else ""
-          env_path.write_text(current_env + f"BOOTSTRAP_BUCKET={cfg['state']['bucket_name']}\n")
+          env_path.write_text(
+              current_env
+              + f"BOOTSTRAP_BUCKET={cfg['state']['bucket_name']}\n"
+              + f"BOOTSTRAP_REGION={cfg['region']}\n"
+              + f"BOOTSTRAP_DYNAMODB_TABLE={cfg['state']['dynamodb_table_name']}\n"
+              + f"BOOTSTRAP_ROLE_NAME={cfg['iam']['role_name']}\n"
+              + f"BOOTSTRAP_TERRAFORM_USER={cfg['iam']['terraform_user_name']}\n"
+          )
           PY
-
-      - name: Empty bootstrap S3 bucket (per config)
-        if: matrix.target == 'bootstrap-s3' && env.DEPLOY_ACTION == 'destroy'
-        env:
-          AWS_REGION: ap-northeast-1
-        run: |
-          aws s3 rb "s3://${BOOTSTRAP_BUCKET}" --force
 
       - name: Init
         working-directory: ${{ env.TF_WORKDIR }}/${{ matrix.target }}
@@ -105,7 +105,16 @@ jobs:
       - name: Destroy
         if: env.DEPLOY_ACTION == 'destroy'
         working-directory: ${{ env.TF_WORKDIR }}/${{ matrix.target }}
-        run: make destroy
+        env:
+          AWS_REGION: ${{ env.BOOTSTRAP_REGION }}
+        run: |
+          if [ "${{ matrix.target }}" = "bootstrap-s3" ]; then
+            make destroy bucket_name=${BOOTSTRAP_BUCKET} region=${BOOTSTRAP_REGION}
+          elif [ "${{ matrix.target }}" = "bootstrap-dynamodb" ]; then
+            make destroy table_name=${BOOTSTRAP_DYNAMODB_TABLE} region=${BOOTSTRAP_REGION}
+          else
+            make destroy role_name=${BOOTSTRAP_ROLE_NAME} terraform_user_name=${BOOTSTRAP_TERRAFORM_USER}
+          fi
 
       - name: Save Outputs
         if: env.DEPLOY_ACTION == 'apply'

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-dynamodb/Makefile
@@ -16,5 +16,6 @@ plan: init
 output: init
 	terraform output
 
-destroy: init
-	terraform destroy $(TF_VARS)
+destroy:
+	@test -n "$(table_name)" || (echo "table_name is required for destroy" && exit 1)
+	aws dynamodb delete-table --table-name "$(table_name)" $(if $(region),--region $(region),)

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-iam/Makefile
@@ -15,5 +15,11 @@ plan: init
 	terraform plan $(TF_VARS)
 output: init
 	terraform output
-destroy: init
-	terraform destroy $(TF_VARS)
+
+destroy:
+	@test -n "$(role_name)" || (echo "role_name is required for destroy" && exit 1)
+	@test -n "$(terraform_user_name)" || (echo "terraform_user_name is required for destroy" && exit 1)
+	aws iam delete-user-policy --user-name "$(terraform_user_name)" --policy-name "$(terraform_user_name)-iac-policy" || true
+	aws iam delete-user --user-name "$(terraform_user_name)" || true
+	aws iam detach-role-policy --role-name "$(role_name)" --policy-arn arn:aws:iam::aws:policy/AdministratorAccess || true
+	aws iam delete-role --role-name "$(role_name)" || true

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap-s3/Makefile
@@ -17,5 +17,6 @@ plan: init
 output: init
 	terraform output
 
-destroy: init
-	terraform destroy $(TF_VARS)
+destroy:
+	@test -n "$(bucket_name)" || (echo "bucket_name is required for destroy" && exit 1)
+	aws s3 rb "s3://$(bucket_name)" --force $(if $(region),--region $(region),)


### PR DESCRIPTION
## Summary
- load bootstrap configuration for destroy runs to expose resource names for AWS CLI cleanup
- update destroy workflow step to pass resource values into make targets per module
- replace bootstrap module destroy targets with AWS CLI removal commands for S3, DynamoDB, and IAM resources

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a923420c8332a10499cf5a86c60f)