### PR TITLE
Enable IAM API before creating GCP bootstrap service account

### DIFF
--- a/iac-template/terraform-hcl-standard/gcp-cloud/bootstrap-iam/main.tf
+++ b/iac-template/terraform-hcl-standard/gcp-cloud/bootstrap-iam/main.tf
@@ -28,10 +28,20 @@ variable "service_account_roles" {
   ]
 }
 
+resource "google_project_service" "iam" {
+  project = var.project_id
+  service = "iam.googleapis.com"
+
+  # Prevent accidental disablement of a core API when destroying the stack
+  disable_on_destroy = false
+}
+
 resource "google_service_account" "bootstrap" {
   account_id   = var.service_account_id
   display_name = "Terraform Bootstrap"
   project      = var.project_id
+
+  depends_on = [google_project_service.iam]
 }
 
 resource "google_project_iam_member" "bootstrap" {


### PR DESCRIPTION
## Summary
- ensure the IAM API is enabled before creating the bootstrap service account
- keep the IAM API enabled on destroy to avoid breaking the project

## Testing
- terraform -chdir=iac-template/terraform-hcl-standard/gcp-cloud/bootstrap-iam fmt *(fails: terraform not installed in CI image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69377eec2b588332a2bd3725ffa822fa)