### PR TITLE
Fix bootstrap output aggregation globbing

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-global-bootstrap.yaml
@@ -142,6 +142,7 @@ jobs:
 
       - name: Merge Outputs
         run: |
+          shopt -s globstar nullglob
           echo "{" > final_bootstrap_outputs.json
           f=true
           for x in outputs/**/outputs_*.json; do


### PR DESCRIPTION
## Summary
- enable globstar and nullglob before merging bootstrap outputs to handle downloaded artifacts

## Testing
- Not run (CI workflow change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937d1d4aae883328d24a05cc8306d33)