### PR TITLE
Add Alicloud Terraform pipeline workflows

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-account-matrix.yaml
@@ -1,0 +1,67 @@
+name: Terraform Standard - IAC Pipeline (Alicloud Account/VPC Matrix)
+
+on:
+  push:
+    paths:
+      - 'iac-template/terraform-hcl-standard/ali-cloud/modules/vpc/**'
+      - 'iac-template/terraform-hcl-standard/ali-cloud/modules/ram/**'
+      - 'iac-template/terraform-hcl-standard/ali-cloud/envs/dev/**'
+      - '.github/workflows/terraform-standard-iac-pipeline-alicloud-account-matrix.yaml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: choice
+        options: ['true', 'false']
+        default: 'true'
+
+env:
+  BASE_DIR: iac-template/terraform-hcl-standard/ali-cloud/envs
+  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
+
+jobs:
+  terraform:
+    name: "${{ matrix.env }} :: pipeline (dry_run=${{ inputs.dry_run }})"
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.5
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.51.0
+
+      - name: Export Alicloud credentials
+        run: |
+          echo "ALICLOUD_ACCESS_KEY=${{ secrets.ALICLOUD_ACCESS_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_SECRET_KEY=${{ secrets.ALICLOUD_SECRET_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_REGION=${ALICLOUD_REGION:-cn-hangzhou}" >> "$GITHUB_ENV"
+          echo "TF_VAR_rds_password=${{ secrets.ALICLOUD_RDS_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_redis_password=${{ secrets.ALICLOUD_REDIS_PASSWORD }}" >> "$GITHUB_ENV"
+
+      - name: Init
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} init -upgrade
+
+      - name: Plan
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} plan
+
+      - name: Apply
+        if: ${{ env.DRY_RUN == 'false' }}
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} apply -auto-approve
+
+      - name: Skip Apply (dry-run)
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: echo "Dry run enabled → skip apply step."
+
+      - name: Output
+        if: ${{ env.DRY_RUN == 'false' }}
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} output -json

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-bootstrap.yaml
@@ -1,0 +1,115 @@
+name: Terraform Standard - Alicloud Account Bootstrap
+
+concurrency:
+  group: terraform-alicloud-bootstrap-${{ github.ref }}
+  cancel-in-progress: false
+
+on:
+  push:
+    paths:
+      - 'iac-template/terraform-hcl-standard/ali-cloud/bootstrap/**'
+      - '.github/workflows/terraform-standard-iac-pipeline-alicloud-bootstrap.yaml'
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      deploy_action:
+        type: choice
+        options: [plan, apply, destroy]
+        default: plan
+
+env:
+  TF_WORKDIR: iac-template/terraform-hcl-standard/ali-cloud/bootstrap
+  DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
+  ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
+
+jobs:
+  bootstrap:
+    name: "Bootstrap ${{ matrix.target }}"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [state, lock, identity]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Document Bootstrap Scope (Alicloud)
+        run: |
+          cat <<'SUMMARY' >> "$GITHUB_STEP_SUMMARY"
+          ## Alicloud bootstrap scope
+          - state: provision OSS bucket for remote state storage
+          - lock: create Table Store instance/table for Terraform state locking
+          - identity: provision RAM role/user plus access keys for automation
+
+          Resource names and defaults follow iac-template/terraform-hcl-standard/ali-cloud/bootstrap.
+          SUMMARY
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.5
+
+      - name: Export Alicloud credentials and variables
+        run: |
+          echo "ALICLOUD_ACCESS_KEY=${{ secrets.ALICLOUD_ACCESS_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_SECRET_KEY=${{ secrets.ALICLOUD_SECRET_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_REGION=${ALICLOUD_REGION:-cn-hangzhou}" >> "$GITHUB_ENV"
+          echo "TF_VAR_state_bucket=${{ secrets.ALICLOUD_STATE_BUCKET }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_account_id=${{ secrets.ALICLOUD_ACCOUNT_ID }}" >> "$GITHUB_ENV"
+
+      - name: Terraform Init
+        run: terraform -chdir=${{ env.TF_WORKDIR }}/${{ matrix.target }} init -upgrade
+
+      - name: Terraform Plan
+        if: env.DEPLOY_ACTION == 'plan'
+        run: terraform -chdir=${{ env.TF_WORKDIR }}/${{ matrix.target }} plan -no-color
+
+      - name: Terraform Apply
+        if: env.DEPLOY_ACTION == 'apply'
+        run: terraform -chdir=${{ env.TF_WORKDIR }}/${{ matrix.target }} apply -auto-approve
+
+      - name: Terraform Destroy
+        if: env.DEPLOY_ACTION == 'destroy'
+        run: terraform -chdir=${{ env.TF_WORKDIR }}/${{ matrix.target }} destroy -auto-approve
+
+      - name: Save Outputs
+        if: env.DEPLOY_ACTION == 'apply'
+        run: terraform -chdir=${{ env.TF_WORKDIR }}/${{ matrix.target }} output -json > ../outputs_${{ matrix.target }}.json
+
+      - uses: actions/upload-artifact@v4
+        if: env.DEPLOY_ACTION == 'apply'
+        with:
+          name: outputs-${{ matrix.target }}
+          path: iac-template/terraform-hcl-standard/ali-cloud/outputs_${{ matrix.target }}.json
+          retention-days: 30
+
+  aggregate:
+    name: "Aggregate Bootstrap Outputs"
+    runs-on: ubuntu-latest
+    needs: bootstrap
+
+    if: ${{ github.event.inputs.deploy_action == 'apply' }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./outputs
+
+      - name: Merge Outputs
+        run: |
+          shopt -s globstar nullglob
+          echo "{" > final_bootstrap_outputs.json
+          f=true
+          for x in outputs/**/outputs_*.json; do
+            k=$(basename $x .json | sed 's/outputs_//')
+            [ "$f" = true ] && f=false || echo "," >> final_bootstrap_outputs.json
+            echo "\"$k\": $(cat $x)" >> final_bootstrap_outputs.json
+          done
+          echo "}" >> final_bootstrap_outputs.json
+
+      - run: cat final_bootstrap_outputs.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: alicloud-bootstrap-final-output
+          path: final_bootstrap_outputs.json

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-landingzone-baseline.yaml
@@ -1,0 +1,104 @@
+name: Terraform Standard - Alicloud Global LandingZone Baseline
+
+on:
+  push:
+    paths:
+      - 'iac-template/terraform-hcl-standard/ali-cloud/**'
+      - '.github/workflows/terraform-standard-iac-pipeline-alicloud-landingzone-baseline.yaml'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      deploy_action:
+        description: "Deployment action"
+        type: choice
+        options: [plan, apply, destroy]
+        default: plan
+      deploy_dry_run:
+        description: "Dry-run mode"
+        type: choice
+        options: ['true', 'false']
+        default: 'true'
+
+env:
+  TF_WORKDIR: iac-template/terraform-hcl-standard/ali-cloud
+  DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
+  ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
+
+jobs:
+  landingzone:
+    name: "Deploy LandingZone Baseline"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.5
+
+      - name: Export Alicloud credentials
+        run: |
+          echo "ALICLOUD_ACCESS_KEY=${{ secrets.ALICLOUD_ACCESS_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_SECRET_KEY=${{ secrets.ALICLOUD_SECRET_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_REGION=${ALICLOUD_REGION:-cn-hangzhou}" >> "$GITHUB_ENV"
+          echo "TF_VAR_rds_password=${{ secrets.ALICLOUD_RDS_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_redis_password=${{ secrets.ALICLOUD_REDIS_PASSWORD }}" >> "$GITHUB_ENV"
+
+      - name: Terraform Init (LandingZone)
+        working-directory: ${{ env.TF_WORKDIR }}/envs/dev
+        run: terraform init -upgrade
+
+      - name: Terraform Plan (LandingZone)
+        id: tfplan
+        if: env.DEPLOY_ACTION == 'plan'
+        working-directory: ${{ env.TF_WORKDIR }}/envs/dev
+        run: terraform plan -no-color > plan_output.txt
+
+      - name: Upload LandingZone Plan Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: alicloud-landingzone-plan
+          path: ${{ env.TF_WORKDIR }}/envs/dev/plan_output.txt
+
+      - name: Terraform Apply (LandingZone)
+        if: env.DEPLOY_ACTION == 'apply'
+        working-directory: ${{ env.TF_WORKDIR }}/envs/dev
+        run: terraform apply -auto-approve
+
+      - name: Terraform Destroy (LandingZone)
+        if: env.DEPLOY_ACTION == 'destroy'
+        working-directory: ${{ env.TF_WORKDIR }}/envs/dev
+        run: terraform destroy -auto-approve
+
+  validation:
+    name: "Validate LandingZone Baseline"
+    needs: landingzone
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Validation Checks
+        run: |
+          echo "⚙️ Running LandingZone baseline validation..."
+          chmod +x scripts/validation/validate-landingzone.sh
+          scripts/validation/validate-landingzone.sh \
+            ${{ env.TF_WORKDIR }}/envs/dev
+
+  delivery:
+    name: "Delivery: Notify Rollout"
+    needs: validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Notify
+        env:
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          SMTP_USERNAME: "manbuzhe2009@qq.com"
+        run: |
+          echo "📣 Sending Alicloud LandingZone rollout notification..."
+          chmod +x scripts/notifications/notify-landingzone.sh
+          ./scripts/notifications/notify-landingzone.sh

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-resources-matrix.yaml
@@ -1,0 +1,66 @@
+name: Terraform Standard - IAC Pipeline (Alicloud Resources Matrix)
+
+on:
+  push:
+    paths:
+      - 'iac-template/terraform-hcl-standard/ali-cloud/modules/**'
+      - 'iac-template/terraform-hcl-standard/ali-cloud/envs/dev/**'
+      - '.github/workflows/terraform-standard-iac-pipeline-alicloud-resources-matrix.yaml'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: choice
+        options: ['true', 'false']
+        default: 'true'
+
+env:
+  BASE_DIR: iac-template/terraform-hcl-standard/ali-cloud/envs
+  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
+
+jobs:
+  terraform:
+    name: "${{ matrix.env }} :: resources (dry_run=${{ inputs.dry_run }})"
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.5
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.51.0
+
+      - name: Export Alicloud credentials
+        run: |
+          echo "ALICLOUD_ACCESS_KEY=${{ secrets.ALICLOUD_ACCESS_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_SECRET_KEY=${{ secrets.ALICLOUD_SECRET_KEY }}" >> "$GITHUB_ENV"
+          echo "ALICLOUD_REGION=${ALICLOUD_REGION:-cn-hangzhou}" >> "$GITHUB_ENV"
+          echo "TF_VAR_rds_password=${{ secrets.ALICLOUD_RDS_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "TF_VAR_redis_password=${{ secrets.ALICLOUD_REDIS_PASSWORD }}" >> "$GITHUB_ENV"
+
+      - name: Init
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} init -upgrade
+
+      - name: Plan
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} plan
+
+      - name: Apply
+        if: ${{ env.DRY_RUN == 'false' }}
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} apply -auto-approve
+
+      - name: Skip Apply (dry-run)
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: echo "Dry run enabled → skip apply step."
+
+      - name: Output
+        if: ${{ env.DRY_RUN == 'false' }}
+        run: terraform -chdir=${{ env.BASE_DIR }}/${{ matrix.env }} output -json


### PR DESCRIPTION
## Summary
- add Alicloud account/VPC and resources matrix Terraform workflows
- introduce Alicloud landing zone baseline pipeline with validation and notification stages
- include Alicloud bootstrap workflow covering state, lock, and identity modules with aggregated outputs

## Testing
- not run (workflows only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693833e729c88332b39f82721ab7caeb)