### PR TITLE
Fix bootstrap config path references

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  bootstrap = yamldecode(file("${path.root}/../../config/accounts/bootstrap.yaml"))
+  bootstrap = yamldecode(file("${path.module}/../../config/accounts/bootstrap.yaml"))
 
   config_account_name     = coalesce(var.account_name, local.bootstrap.account_name)
   config_region           = coalesce(var.region, local.bootstrap.region)
@@ -10,7 +10,7 @@ locals {
 }
 
 locals {
-  account_file_path = "${path.root}/../../../config/accounts/${local.config_account_name}.yaml"
+  account_file_path = "${path.module}/../../../config/accounts/${local.config_account_name}.yaml"
   account = fileexists(local.account_file_path) ? yamldecode(file(local.account_file_path)) : {
     account_id  = local.bootstrap.account_id
     environment = local.environment

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/lock/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/lock/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  bootstrap = yamldecode(file("${path.root}/../../config/accounts/bootstrap.yaml"))
+  bootstrap = yamldecode(file("${path.module}/../../config/accounts/bootstrap.yaml"))
 
   dynamodb_table_name = coalesce(var.table_name, local.bootstrap.state.dynamodb_table_name)
   region              = coalesce(var.region, local.bootstrap.region)

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  bootstrap = yamldecode(file("${path.root}/../../config/accounts/bootstrap.yaml"))
+  bootstrap = yamldecode(file("${path.module}/../../config/accounts/bootstrap.yaml"))
 
   bucket_name = coalesce(var.bucket_name, local.bootstrap.state.bucket_name)
   region      = coalesce(var.region, local.bootstrap.region)


### PR DESCRIPTION
## Summary
- use `path.module` for bootstrap configuration file lookups across AWS bootstrap modules
- ensure account configuration paths resolve correctly regardless of invocation location

## Testing
- terraform fmt *(fails: terraform not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938faf37cb88332b72d754dac7383b9)