### PR TITLE
Fix AWS account matrix workflow paths

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
@@ -3,9 +3,9 @@ name: IAC Pipeline AWS Cloud (Account/VPC Matrix)
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/aws-cloud/instance/vpc/**'
-      - 'iac-template/terraform-hcl-standard/aws-cloud/instance/role/**'
-      - '.github/workflows/terraform-standard-iac-pipeline-account-matrix.yaml'
+      - 'iac-template/terraform-hcl-standard/aws-cloud/component/vpc/**'
+      - 'iac-template/terraform-hcl-standard/aws-cloud/component/role/**'
+      - '.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -15,12 +15,12 @@ on:
 
 env:
   AWS_REGION: ap-northeast-1
-  BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/instance/
+  BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component/
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
 
 jobs:
   terraform:
-    name: "${{ matrix.env }} :: pipeline (dry_run=${{ inputs.dry_run }})"
+    name: "${{ matrix.component }} :: pipeline (dry_run=${{ inputs.dry_run }})"
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Summary
- update AWS workflow triggers to monitor component directories
- point workflow working directory to existing component path and show component name in job title

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390402ed748332950e32127302a219)