### PR TITLE
Fix NAT EIP configuration for VPC compatibility

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/modules/vpc/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/modules/vpc/main.tf
@@ -43,7 +43,7 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_eip" "nat" {
-  vpc = true
+  domain = "vpc"
 
   tags = merge(var.tags, {
     Name = "${var.name_prefix}-nat-eip"


### PR DESCRIPTION
## Summary
- replace deprecated aws_eip vpc argument with supported domain configuration for NAT gateway allocation

## Testing
- not run (terraform CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390da6c8ec8332baa33a26f183e1a2)