### PR TITLE
Allow bootstrapping with existing IAM identity

### DIFF
--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/main.tf
@@ -9,8 +9,8 @@ terraform {
 
 provider "alicloud" {
   region         = var.region
-  access_key     = coalesce(var.access_key, "mock-access-key")
-  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  access_key     = var.access_key
+  secret_key     = var.secret_key
   security_token = var.security_token
 
   dynamic "assume_role" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/main.tf
@@ -8,7 +8,18 @@ terraform {
 }
 
 provider "alicloud" {
-  region = var.region
+  region         = var.region
+  access_key     = coalesce(var.access_key, "mock-access-key")
+  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  security_token = var.security_token
+
+  dynamic "assume_role" {
+    for_each = var.ram_role_arn == null ? [] : [var.ram_role_arn]
+    content {
+      role_arn     = assume_role.value
+      session_name = var.session_name
+    }
+  }
 }
 
 locals {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/variables.tf
@@ -8,6 +8,11 @@ variable "access_key" {
   description = "Alibaba Cloud Access Key ID"
   type        = string
   default     = null
+
+  validation {
+    condition     = (var.access_key == null && var.secret_key == null) || (var.access_key != null && var.secret_key != null)
+    error_message = "Provide both access_key and secret_key, or leave both null to rely on environment-sourced credentials."
+  }
 }
 
 variable "secret_key" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/identity/variables.tf
@@ -4,6 +4,38 @@ variable "region" {
   default     = "cn-hangzhou"
 }
 
+variable "access_key" {
+  description = "Alibaba Cloud Access Key ID"
+  type        = string
+  default     = null
+}
+
+variable "secret_key" {
+  description = "Alibaba Cloud Access Key Secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "security_token" {
+  description = "Optional security token when using STS credentials"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "ram_role_arn" {
+  description = "Optional RAM role ARN to assume for operations"
+  type        = string
+  default     = null
+}
+
+variable "session_name" {
+  description = "Session name when assuming a RAM role"
+  type        = string
+  default     = "terraform"
+}
+
 variable "account_id" {
   description = "Alibaba Cloud account ID used for trust policy"
   type        = string

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/main.tf
@@ -9,8 +9,8 @@ terraform {
 
 provider "alicloud" {
   region         = var.region
-  access_key     = coalesce(var.access_key, "mock-access-key")
-  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  access_key     = var.access_key
+  secret_key     = var.secret_key
   security_token = var.security_token
 
   dynamic "assume_role" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/main.tf
@@ -8,7 +8,18 @@ terraform {
 }
 
 provider "alicloud" {
-  region = var.region
+  region         = var.region
+  access_key     = coalesce(var.access_key, "mock-access-key")
+  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  security_token = var.security_token
+
+  dynamic "assume_role" {
+    for_each = var.ram_role_arn == null ? [] : [var.ram_role_arn]
+    content {
+      role_arn     = assume_role.value
+      session_name = var.session_name
+    }
+  }
 }
 
 resource "alicloud_ots_instance" "this" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/variables.tf
@@ -8,6 +8,11 @@ variable "access_key" {
   description = "Alibaba Cloud Access Key ID"
   type        = string
   default     = null
+
+  validation {
+    condition     = (var.access_key == null && var.secret_key == null) || (var.access_key != null && var.secret_key != null)
+    error_message = "Provide both access_key and secret_key, or leave both null to rely on environment-sourced credentials."
+  }
 }
 
 variable "secret_key" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/lock/variables.tf
@@ -4,6 +4,38 @@ variable "region" {
   default     = "cn-hangzhou"
 }
 
+variable "access_key" {
+  description = "Alibaba Cloud Access Key ID"
+  type        = string
+  default     = null
+}
+
+variable "secret_key" {
+  description = "Alibaba Cloud Access Key Secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "security_token" {
+  description = "Optional security token when using STS credentials"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "ram_role_arn" {
+  description = "Optional RAM role ARN to assume for operations"
+  type        = string
+  default     = null
+}
+
+variable "session_name" {
+  description = "Session name when assuming a RAM role"
+  type        = string
+  default     = "terraform"
+}
+
 variable "instance_name" {
   description = "Name of the OTS instance"
   type        = string

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/state/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/state/main.tf
@@ -9,8 +9,8 @@ terraform {
 
 provider "alicloud" {
   region         = var.region
-  access_key     = coalesce(var.access_key, "mock-access-key")
-  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  access_key     = var.access_key
+  secret_key     = var.secret_key
   security_token = var.security_token
 
   dynamic "assume_role" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/state/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/state/variables.tf
@@ -8,6 +8,11 @@ variable "access_key" {
   description = "Alibaba Cloud Access Key ID"
   type        = string
   default     = null
+
+  validation {
+    condition     = (var.access_key == null && var.secret_key == null) || (var.access_key != null && var.secret_key != null)
+    error_message = "Provide both access_key and secret_key, or leave both null to rely on environment-sourced credentials."
+  }
 }
 
 variable "secret_key" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/state/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/bootstrap/state/variables.tf
@@ -4,6 +4,38 @@ variable "region" {
   default     = "cn-hangzhou"
 }
 
+variable "access_key" {
+  description = "Alibaba Cloud Access Key ID"
+  type        = string
+  default     = null
+}
+
+variable "secret_key" {
+  description = "Alibaba Cloud Access Key Secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "security_token" {
+  description = "Optional security token when using STS credentials"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "ram_role_arn" {
+  description = "Optional RAM role ARN to assume for operations"
+  type        = string
+  default     = null
+}
+
+variable "session_name" {
+  description = "Session name when assuming a RAM role"
+  type        = string
+  default     = "terraform"
+}
+
 variable "state_bucket" {
   description = "Name of the OSS bucket used for remote state"
   type        = string

--- a/iac-template/terraform-hcl-standard/ali-cloud/envs/dev/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/envs/dev/main.tf
@@ -9,7 +9,18 @@ terraform {
 }
 
 provider "alicloud" {
-  region = var.region
+  region         = var.region
+  access_key     = coalesce(var.access_key, "mock-access-key")
+  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  security_token = var.security_token
+
+  dynamic "assume_role" {
+    for_each = var.ram_role_arn == null ? [] : [var.ram_role_arn]
+    content {
+      role_arn     = assume_role.value
+      session_name = var.session_name
+    }
+  }
 }
 
 module "network" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/envs/dev/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/envs/dev/variables.tf
@@ -4,6 +4,38 @@ variable "region" {
   default     = "cn-hangzhou"
 }
 
+variable "access_key" {
+  description = "Alibaba Cloud Access Key ID"
+  type        = string
+  default     = null
+}
+
+variable "secret_key" {
+  description = "Alibaba Cloud Access Key Secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "security_token" {
+  description = "Optional security token when using STS credentials"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "ram_role_arn" {
+  description = "Optional RAM role ARN to assume for operations"
+  type        = string
+  default     = null
+}
+
+variable "session_name" {
+  description = "Session name when assuming a RAM role"
+  type        = string
+  default     = "terraform"
+}
+
 variable "vpc_name" {
   description = "VPC name"
   type        = string

--- a/iac-template/terraform-hcl-standard/ali-cloud/modules/oss/main.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/modules/oss/main.tf
@@ -1,6 +1,5 @@
 resource "alicloud_oss_bucket" "this" {
   bucket = var.name
-  acl    = var.acl
 
   versioning {
     status = var.enable_versioning ? "Enabled" : "Suspended"
@@ -9,6 +8,11 @@ resource "alicloud_oss_bucket" "this" {
   server_side_encryption_rule {
     sse_algorithm = var.sse_algorithm
   }
+}
+
+resource "alicloud_oss_bucket_acl" "this" {
+  bucket = alicloud_oss_bucket.this.bucket
+  acl    = var.acl
 }
 
 output "bucket" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/templates/provider.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/templates/provider.tf
@@ -9,8 +9,8 @@ terraform {
 
 provider "alicloud" {
   region         = var.region
-  access_key     = coalesce(var.access_key, "mock-access-key")
-  secret_key     = coalesce(var.secret_key, "mock-secret-key")
+  access_key     = var.access_key
+  secret_key     = var.secret_key
   security_token = var.security_token
 
   dynamic "assume_role" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/templates/provider.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/templates/provider.tf
@@ -9,8 +9,8 @@ terraform {
 
 provider "alicloud" {
   region         = var.region
-  access_key     = var.access_key
-  secret_key     = var.secret_key
+  access_key     = coalesce(var.access_key, "mock-access-key")
+  secret_key     = coalesce(var.secret_key, "mock-secret-key")
   security_token = var.security_token
 
   dynamic "assume_role" {

--- a/iac-template/terraform-hcl-standard/ali-cloud/templates/variables.tf
+++ b/iac-template/terraform-hcl-standard/ali-cloud/templates/variables.tf
@@ -8,6 +8,11 @@ variable "access_key" {
   description = "Alibaba Cloud Access Key ID"
   type        = string
   default     = null
+
+  validation {
+    condition     = (var.access_key == null && var.secret_key == null) || (var.access_key != null && var.secret_key != null)
+    error_message = "Provide both access_key and secret_key, or leave both null to rely on environment-sourced credentials."
+  }
 }
 
 variable "secret_key" {

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/locals.tf
@@ -7,6 +7,9 @@ locals {
   config_terraform_user   = coalesce(var.terraform_user_name, local.bootstrap.iam.terraform_user_name)
   environment             = coalesce(try(local.bootstrap.environment, null), try(local.bootstrap.iam.environment, null), "bootstrap")
   extra_tags              = try(local.bootstrap.tags, {})
+
+  role_name          = coalesce(var.existing_role_name, local.config_role_name)
+  terraform_user_name = coalesce(var.existing_user_name, local.config_terraform_user)
 }
 
 locals {

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/outputs.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/outputs.tf
@@ -1,9 +1,9 @@
 output "iam_role_arn" {
-  value       = aws_iam_role.terraform_deploy_role.arn
+  value       = var.create_role ? aws_iam_role.terraform_deploy_role[0].arn : var.existing_role_arn
   description = "The ARN of the role assumed by Terraform"
 }
 
 output "terraform_user_name" {
-  value       = aws_iam_user.terraform_user.name
+  value       = var.create_user ? aws_iam_user.terraform_user[0].name : local.terraform_user_name
   description = "Terraform IAM User"
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/variables.tf
@@ -14,6 +14,11 @@ variable "create_role" {
   description = "Whether to create the Terraform deploy IAM role"
   type        = bool
   default     = true
+
+  validation {
+    condition     = var.create_role || (var.existing_role_arn != null && var.existing_role_name != null)
+    error_message = "existing_role_name and existing_role_arn must be provided when create_role is false."
+  }
 }
 
 variable "existing_role_name" {
@@ -34,12 +39,6 @@ variable "role_name" {
   default     = null
 }
 
-variable "create_user" {
-  description = "Whether to create the IAM user for Terraform"
-  type        = bool
-  default     = true
-}
-
 variable "existing_user_name" {
   description = "Existing IAM username to reference when create_user is false"
   type        = string
@@ -52,12 +51,13 @@ variable "terraform_user_name" {
   default     = null
 }
 
-validation "require_existing_role_arn_when_not_creating" {
-  condition     = var.create_role || (var.existing_role_arn != null && var.existing_role_name != null)
-  error_message = "existing_role_name and existing_role_arn must be provided when create_role is false."
-}
+variable "create_user" {
+  description = "Whether to create the IAM user for Terraform"
+  type        = bool
+  default     = true
 
-validation "require_existing_user_name_when_not_creating" {
-  condition     = var.create_user || var.existing_user_name != null
-  error_message = "existing_user_name must be provided when create_user is false."
+  validation {
+    condition     = var.create_user || var.existing_user_name != null
+    error_message = "existing_user_name must be provided when create_user is false."
+  }
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/variables.tf
@@ -10,9 +10,39 @@ variable "account_name" {
   default     = null
 }
 
+variable "create_role" {
+  description = "Whether to create the Terraform deploy IAM role"
+  type        = bool
+  default     = true
+}
+
+variable "existing_role_name" {
+  description = "Existing IAM role name to reference when create_role is false"
+  type        = string
+  default     = null
+}
+
+variable "existing_role_arn" {
+  description = "Existing IAM role ARN to reference when create_role is false"
+  type        = string
+  default     = null
+}
+
 variable "role_name" {
   type        = string
   description = "IAM role name to create (e.g., TerraformDeployRole-Dev)"
+  default     = null
+}
+
+variable "create_user" {
+  description = "Whether to create the IAM user for Terraform"
+  type        = bool
+  default     = true
+}
+
+variable "existing_user_name" {
+  description = "Existing IAM username to reference when create_user is false"
+  type        = string
   default     = null
 }
 
@@ -20,4 +50,14 @@ variable "terraform_user_name" {
   type        = string
   description = "IAM username for Terraform IAC runner"
   default     = null
+}
+
+validation "require_existing_role_arn_when_not_creating" {
+  condition     = var.create_role || (var.existing_role_arn != null && var.existing_role_name != null)
+  error_message = "existing_role_name and existing_role_arn must be provided when create_role is false."
+}
+
+validation "require_existing_user_name_when_not_creating" {
+  condition     = var.create_user || var.existing_user_name != null
+  error_message = "existing_user_name must be provided when create_user is false."
 }


### PR DESCRIPTION
## Summary
- add flags to reuse pre-existing IAM role or user during bootstrap
- guard outputs and policies with optional IAM resource selection
- validate required inputs when skipping IAM creation

## Testing
- not run (terraform CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391845d51c833285374949e55ad7db)