### PR TITLE
Fix Terragrunt bootstrap locals resolution

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
@@ -3,7 +3,8 @@ include "root" {
 }
 
 locals {
-  bootstrap_config = include.root.locals.bootstrap_config
+  root_config      = read_terragrunt_config(find_in_parent_folders())
+  bootstrap_config = local.root_config.locals.bootstrap_config
 }
 
 dependency "state" {

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
@@ -3,7 +3,8 @@ include "root" {
 }
 
 locals {
-  bootstrap_config = include.root.locals.bootstrap_config
+  root_config      = read_terragrunt_config(find_in_parent_folders())
+  bootstrap_config = local.root_config.locals.bootstrap_config
 }
 
 dependency "state" {

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
@@ -3,7 +3,8 @@ include "root" {
 }
 
 locals {
-  bootstrap_config = include.root.locals.bootstrap_config
+  root_config      = read_terragrunt_config(find_in_parent_folders())
+  bootstrap_config = local.root_config.locals.bootstrap_config
 }
 
 terraform {


### PR DESCRIPTION
## Summary
- ensure bootstrap Terragrunt modules load parent locals via read_terragrunt_config
- prevent null include locals when accessing shared bootstrap configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939342df4b8833299c6279cc8c829f6)