### PR TITLE
Fix bootstrap config path

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/terragrunt.hcl
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/terragrunt.hcl
@@ -2,5 +2,5 @@ terraform_version_constraint  = ">= 1.2.0"
 terragrunt_version_constraint = ">= 0.67.14"
 
 locals {
-  bootstrap_config = yamldecode(file("${get_terragrunt_dir()}/../config/accounts/bootstrap.yaml"))
+  bootstrap_config = yamldecode(file("${get_original_terragrunt_dir()}/../config/accounts/bootstrap.yaml"))
 }


### PR DESCRIPTION
## Summary
- load bootstrap configuration using get_original_terragrunt_dir to ensure the file is found when Terragrunt copies configs to cache

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693937824c888332aadcc07993902f1f)