### PR TITLE
Make state bucket creation optional

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/locals.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/locals.tf
@@ -5,4 +5,7 @@ locals {
   region      = coalesce(var.region, local.bootstrap.region)
   environment = try(local.bootstrap.environment, "bootstrap")
   tags        = try(local.bootstrap.tags, {})
+
+  bucket_arn = var.create_bucket ? aws_s3_bucket.state[0].arn : data.aws_s3_bucket.existing[0].arn
+  bucket_id  = var.create_bucket ? aws_s3_bucket.state[0].id : data.aws_s3_bucket.existing[0].id
 }

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/main.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket" "state" {
+  count  = var.create_bucket ? 1 : 0
   bucket = local.bucket_name
 
   tags = merge(
@@ -10,8 +11,14 @@ resource "aws_s3_bucket" "state" {
   )
 }
 
+data "aws_s3_bucket" "existing" {
+  count  = var.create_bucket ? 0 : 1
+  bucket = local.bucket_name
+}
+
 resource "aws_s3_bucket_versioning" "versioning" {
-  bucket = aws_s3_bucket.state.id
+  count  = var.create_bucket ? 1 : 0
+  bucket = local.bucket_id
 
   versioning_configuration {
     status = "Enabled"
@@ -19,7 +26,8 @@ resource "aws_s3_bucket_versioning" "versioning" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
-  bucket = aws_s3_bucket.state.id
+  count  = var.create_bucket ? 1 : 0
+  bucket = local.bucket_id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -29,7 +37,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse" {
 }
 
 resource "aws_s3_bucket_public_access_block" "block" {
-  bucket = aws_s3_bucket.state.id
+  count  = var.create_bucket ? 1 : 0
+  bucket = local.bucket_id
 
   block_public_acls       = true
   block_public_policy     = true

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/outputs.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/outputs.tf
@@ -1,9 +1,9 @@
 output "bucket_name" {
-  value = aws_s3_bucket.state.bucket
+  value = local.bucket_name
 }
 
 output "bucket_arn" {
-  value       = aws_s3_bucket.state.arn
+  value       = local.bucket_arn
   description = "ARN of the Terraform state bucket"
 }
 

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/state/variables.tf
@@ -15,3 +15,9 @@ variable "bootstrap_config_path" {
   type        = string
   default     = "../../config/accounts/bootstrap.yaml"
 }
+
+variable "create_bucket" {
+  description = "Whether to create the Terraform state bucket. Set to false to use an existing bucket."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- add a create_bucket switch to allow reusing an existing Terraform state bucket
- look up existing bucket metadata when skipping creation and reuse it in outputs
- gate bucket configuration resources behind the creation toggle

## Testing
- Not run (Terraform CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a91c9bf483328feda0ea077b0392)