### PR TITLE
Configure AWS workflows to assume deploy role

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
@@ -49,6 +49,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: github-actions
+          role-skip-session-tagging: true
 
       - name: Init
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
@@ -17,6 +17,7 @@ env:
   AWS_REGION: ap-northeast-1
   BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component/
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   terraform:
@@ -46,6 +47,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-actions
 
       - name: Init
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -48,6 +48,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: github-actions
+          role-skip-session-tagging: true
 
       - name: Terraform Init (LandingZone)
         working-directory: ${{ env.TF_WORKDIR }}/envs/dev-landingzone

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -23,6 +23,7 @@ on:
 env:
   TF_WORKDIR: iac-template/terraform-hcl-standard/aws-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
+  AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   # -------------------------------------------------------
@@ -45,6 +46,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-actions
 
       - name: Terraform Init (LandingZone)
         working-directory: ${{ env.TF_WORKDIR }}/envs/dev-landingzone

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
@@ -49,6 +49,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: github-actions
+          role-skip-session-tagging: true
 
       - name: Init
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.env }}

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
@@ -17,6 +17,7 @@ env:
   BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/envs
   AWS_REGION: ap-northeast-1
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   terraform:
@@ -46,6 +47,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-actions
 
       - name: Init
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.env }}


### PR DESCRIPTION
## Summary
- add shared deploy role ARN to AWS workflows to support role assumption
- configure AWS credential steps to assume IacDeployRole for matrix and landing zone jobs

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b0e1fd308332803568bb5471eb34)