### PR TITLE
Attach admin policy to terraform deploy role

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
@@ -17,6 +17,7 @@ env:
   AWS_REGION: ap-northeast-1
   BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component/
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   terraform:
@@ -46,6 +47,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-actions
+          role-skip-session-tagging: true
 
       - name: Init
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -23,6 +23,7 @@ on:
 env:
   TF_WORKDIR: iac-template/terraform-hcl-standard/aws-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
+  AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   # -------------------------------------------------------
@@ -45,6 +46,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-actions
+          role-skip-session-tagging: true
 
       - name: Terraform Init (LandingZone)
         working-directory: ${{ env.TF_WORKDIR }}/envs/dev-landingzone

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
@@ -17,6 +17,7 @@ env:
   BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/envs
   AWS_REGION: ap-northeast-1
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   terraform:
@@ -46,6 +47,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: github-actions
+          role-skip-session-tagging: true
 
       - name: Init
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.env }}

--- a/iac-template/terraform-hcl-standard/aws-cloud/README.md
+++ b/iac-template/terraform-hcl-standard/aws-cloud/README.md
@@ -88,6 +88,11 @@ terraform init
 terraform apply \
   -var="account_name=dev" \
   -var="role_name=TerraformDeployRole-Dev"
+
+By default the deploy role attaches the AWS managed **AdministratorAccess** policy so
+subsequent Terraform runs can create infrastructure resources (e.g., VPCs, EIPs). You
+can override this by passing `-var='managed_policy_arns=["arn:aws:iam::aws:policy/PowerUserAccess"]'`
+or another list of managed policy ARNs when tighter permissions are required.
 ```
 
 ## 5. Use in Terraform Backend

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/main.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/main.tf
@@ -52,6 +52,13 @@ resource "aws_iam_role_policy" "terraform_deploy_role_policy" {
   policy = data.aws_iam_policy_document.terraform_deploy_inline.json
 }
 
+resource "aws_iam_role_policy_attachment" "terraform_deploy_role_managed" {
+  count = var.create_role ? length(var.managed_policy_arns) : 0
+
+  role       = aws_iam_role.terraform_deploy_role[0].name
+  policy_arn = var.managed_policy_arns[count.index]
+}
+
 #
 # IAM User for Terraform (AK/SK)
 # ----------------------------------------

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/variables.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/variables.tf
@@ -79,3 +79,9 @@ variable "bootstrap_config_path" {
   type        = string
   default     = "../../config/accounts/bootstrap.yaml"
 }
+
+variable "managed_policy_arns" {
+  description = "List of managed policy ARNs to attach to the Terraform deploy role"
+  type        = list(string)
+  default     = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+}


### PR DESCRIPTION
## Summary
- allow attaching managed policies to the terraform deploy role with a default AdministratorAccess attachment
- document how to override the default managed policy list when provisioning the deploy role

## Testing
- not run (tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b0e1fd308332803568bb5471eb34)