### PR TITLE
Update terraform workflows to use deploy action input

### DIFF
--- a/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml
@@ -8,20 +8,20 @@ on:
       - '.github/workflows/terraform-standard-iac-pipeline-aws-account-matrix.yaml'
   workflow_dispatch:
     inputs:
-      dry_run:
+      deploy_action:
         type: choice
-        options: ['true', 'false']
-        default: 'true'
+        options: [plan, apply, destroy]
+        default: plan
 
 env:
   AWS_REGION: ap-northeast-1
   BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component/
-  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   terraform:
-    name: "${{ matrix.component }} :: pipeline (dry_run=${{ inputs.dry_run }})"
+    name: "${{ matrix.component }} :: pipeline (action=${{ inputs.deploy_action }})"
     runs-on: ubuntu-latest
 
     strategy:
@@ -61,14 +61,19 @@ jobs:
 
       - name: Apply
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}
-        if: ${{ env.DRY_RUN == 'false' }}
+        if: ${{ env.DEPLOY_ACTION == 'apply' }}
         run: make apply
 
-      - name: Skip Apply (dry-run)
-        if: ${{ env.DRY_RUN == 'true' }}
-        run: echo "Dry run enabled → skip apply step."
+      - name: Destroy
+        working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}
+        if: ${{ env.DEPLOY_ACTION == 'destroy' }}
+        run: make destroy
+
+      - name: Skip Apply/Destroy
+        if: ${{ env.DEPLOY_ACTION != 'apply' && env.DEPLOY_ACTION != 'destroy' }}
+        run: echo "Action set to plan → skipping apply/destroy steps."
 
       - name: Output
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}
-        if: ${{ env.DRY_RUN == 'false' }}
+        if: ${{ env.DEPLOY_ACTION == 'apply' }}
         run: terraform output -json

--- a/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml
@@ -8,10 +8,10 @@ on:
       - '.github/workflows/terraform-standard-iac-pipeline-aws-resources-matrix.yaml'
   workflow_dispatch:
     inputs:
-      dry_run:
+      deploy_action:
         type: choice
-        options: ['true', 'false']
-        default: 'true'
+        options: [plan, apply, destroy]
+        default: plan
 
 permissions:
   id-token: write
@@ -20,12 +20,12 @@ permissions:
 env:
   BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component
   AWS_REGION: ap-northeast-1
-  DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+  DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   AWS_ROLE_ARN: arn:aws:iam::950604983695:role/IacDeployRole
 
 jobs:
   terraform:
-    name: "${{ matrix.component }} :: pipeline (dry_run=${{ inputs.dry_run }})"
+    name: "${{ matrix.component }} :: pipeline (action=${{ inputs.deploy_action }})"
     runs-on: ubuntu-latest
 
     strategy:
@@ -65,14 +65,19 @@ jobs:
 
       - name: Apply
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}
-        if: ${{ env.DRY_RUN == 'false' }}
+        if: ${{ env.DEPLOY_ACTION == 'apply' }}
         run: make apply
 
-      - name: Skip Apply (dry-run)
-        if: ${{ env.DRY_RUN == 'true' }}
-        run: echo "Dry run enabled → skip apply step."
+      - name: Destroy
+        working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}
+        if: ${{ env.DEPLOY_ACTION == 'destroy' }}
+        run: make destroy
+
+      - name: Skip Apply/Destroy
+        if: ${{ env.DEPLOY_ACTION != 'apply' && env.DEPLOY_ACTION != 'destroy' }}
+        run: echo "Action set to plan → skipping apply/destroy steps."
 
       - name: Output
         working-directory: ${{ env.BASE_DIR }}/${{ matrix.component }}
-        if: ${{ env.DRY_RUN == 'false' }}
+        if: ${{ env.DEPLOY_ACTION == 'apply' }}
         run: terraform output -json


### PR DESCRIPTION
## Summary
- replace dry_run workflow_dispatch inputs with deploy_action choice across AWS terraform matrix workflows
- propagate deploy_action through environment values and job naming, gating apply/destroy steps accordingly
- add destroy handling and plan-only skip messaging while keeping outputs for apply actions

## Testing
- Not run (workflow configuration change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a811bf5bc8332843570a3bec21a31)