### PR TITLE
Remove import existing step from EC2 Makefile

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/component/ec2/Makefile
+++ b/iac-template/terraform-hcl-standard/aws-cloud/component/ec2/Makefile
@@ -3,17 +3,14 @@
 render:
 	python ../../render_provider_backend.py
 
-init:
+init: render
+	python ../../render_provider_backend.py
 	terraform init --upgrade
 
 plan: init
 	terraform plan
 
-import-existing: init
-	@echo "Reconciling existing AWS resources (key pair / security group)"
-	./import_existing.sh
-
-apply: import-existing
+apply: init
 	terraform apply -auto-approve
 
 output:


### PR DESCRIPTION
## Summary
- ensure EC2 Makefile initialization renders backend configuration
- remove import_existing target and apply dependency on it

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9e9eecac833290a5ce97c0e9bb16)