### PR TITLE
Fix provider backend rendering path and avoid committing generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ coverage.xml
 # Generated Terraform provider/backend files for AWS cloud envs
 iac-template/terraform-hcl-standard/aws-cloud/envs/*/provider.tf
 iac-template/terraform-hcl-standard/aws-cloud/envs/*/backend.tf
+# Generated provider/backend files for component stacks
+iac-template/terraform-hcl-standard/aws-cloud/component/*/provider.tf
+iac-template/terraform-hcl-standard/aws-cloud/component/*/backend.tf
 
 # Ansible
 *.retry

--- a/iac-template/terraform-hcl-standard/aws-cloud/render_provider_backend.py
+++ b/iac-template/terraform-hcl-standard/aws-cloud/render_provider_backend.py
@@ -13,7 +13,7 @@ CONFIG_DIR = Path(
     os.environ.get("AWS_CLOUD_CONFIG_PATH", PROJECT_ROOT / "aws-cloud" / "config")
 )
 TEMPLATE_DIR = CURRENT_DIR / "templates"
-ENVS_DIR = CURRENT_DIR / "envs"
+ENVS_DIR = CURRENT_DIR / "component"
 
 sys.path.append(str(PROJECT_ROOT / "utils"))
 from config_loader import load_merged_config  # noqa: E402
@@ -81,7 +81,10 @@ def render_templates():
     backend_template = env.get_template("backend.tf.j2")
 
     for module_name, module_config in modules.items():
-        module_dir = ENVS_DIR / module_name
+        module_dir_name = module_config.get("component_dir") or module_name.split("-", 1)[
+            -1
+        ]
+        module_dir = ENVS_DIR / module_dir_name
         if not module_dir.exists():
             print(f"⚠️  Skipping {module_name}: {module_dir} not found")
             continue


### PR DESCRIPTION
## Summary
- keep render_provider_backend.py targeting the component directories for provider/backend rendering
- remove generated provider.tf and backend.tf outputs from component stacks and ignore them to prevent committing rendered artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa56d37b08332b82150ae21aa643d)