### PR TITLE
Add component-aware provider/backend rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ coverage.xml
 # Generated Terraform provider/backend files for AWS cloud envs
 iac-template/terraform-hcl-standard/aws-cloud/envs/*/provider.tf
 iac-template/terraform-hcl-standard/aws-cloud/envs/*/backend.tf
+# Generated provider/backend files for component stacks
+iac-template/terraform-hcl-standard/aws-cloud/component/*/provider.tf
+iac-template/terraform-hcl-standard/aws-cloud/component/*/backend.tf
 
 # Ansible
 *.retry

--- a/iac-template/terraform-hcl-standard/aws-cloud/config/provider_backend.yaml
+++ b/iac-template/terraform-hcl-standard/aws-cloud/config/provider_backend.yaml
@@ -36,6 +36,7 @@ modules:
 
   dev-object:
     account: dev
+    component_dir: s3
     backend:
       key: "account/dev/s3/terraform.tfstate"
 


### PR DESCRIPTION
## Summary
- detect when the renderer is executed from within a component directory and render only that component’s provider/backend files
- map the dev-object module to the existing s3 component directory to avoid missing-path warnings
- preserve full rendering behavior for other components while still skipping missing module directories

## Testing
- python ../../render_provider_backend.py
- python render_provider_backend.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa56d37b08332b82150ae21aa643d)