### PR TITLE
Add xzerolab SIT config templates and layout guide

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,72 @@
+# Configuration Layout
+
+This repository keeps environment-specific infrastructure configuration under the `config/` directory. The layout follows a consistent project → environment → cloud/provider → resource-module hierarchy so that each stack can be managed independently.
+
+## Recommended standard layout
+
+```
+config/
+└── <project>/
+    └── <env>/
+        └── <cloud>/
+            ├── base.yaml
+            ├── identity.yaml
+            ├── network.yaml
+            ├── security.yaml
+            ├── storage.yaml
+            ├── compute.yaml
+            ├── observability.yaml
+            └── <feature>.yaml
+```
+
+- **Project**: top-level application or platform (for example `modern-container-app`, `cloudneutral-platform`, or `ai-infra-lab`).
+- **Environment**: fully isolated deployment stages such as `dev`, `sit`, `uat`, and `prod`.
+- **Cloud/Provider**: clear provider identifiers such as `aws-cloud`, `gcp-cloud`, or `vultr-vps`.
+- **Resource modules**: YAML slices for base settings, identity, network, security, storage, compute, observability, and feature-specific needs.
+
+## Applied layout for this repository
+
+The current repo uses the `xzerolab` project with a `sit` environment. Provider-specific configurations are organized per cloud alongside shared assets for future environments.
+
+```
+config/
+├── bootstrap.yaml
+└── xzerolab/
+    └── sit/
+        ├── aws-cloud/
+        │   ├── accounts/
+        │   │   ├── bootstrap.yaml
+        │   │   ├── dev-landingzone.yaml
+        │   │   └── dev.yaml
+        │   ├── provider_backend.yaml
+        │   └── resources/
+        │       ├── dev-alb/alb.yaml
+        │       ├── dev-kafka/msk.yaml
+        │       ├── dev-nlb/nlb.yaml
+        │       ├── dev-object/bucket.yaml
+        │       ├── dev-rds/rds.yaml
+        │       ├── dev-redis/redis.yaml
+        │       ├── ec2/dev.yaml
+        │       └── vpc/dev.yaml
+        ├── gcp-cloud/
+        │   ├── accounts/
+        │   │   ├── bootstrap.yaml
+        │   │   ├── dev-landingzone.yaml
+        │   │   └── dev.yaml
+        │   └── resources/
+        │       ├── dev-alb/alb.yaml
+        │       ├── dev-kafka/msk.yaml
+        │       ├── dev-nlb/nlb.yaml
+        │       ├── dev-object/bucket.yaml
+        │       ├── dev-rds/rds.yaml
+        │       ├── dev-redis/redis.yaml
+        │       ├── ec2/dev.yaml
+        │       └── vpc/dev.yaml
+        └── vultr-vps/
+            ├── accounts/
+            │   └── .gitkeep
+            └── resources/
+                └── .gitkeep
+```
+
+Use this layout to keep each environment and provider self-contained, making it easy for CI/CD workflows to target the exact configuration needed for a deployment.

--- a/config/bootstrap.yaml
+++ b/config/bootstrap.yaml
@@ -1,0 +1,17 @@
+region: ap-northeast-1
+environment: bootstrap
+
+account_name: xzerolab
+account_id: 950604983695
+
+state:
+  bucket_name: aws-cloud-iac-state
+  dynamodb_table_name: aws-cloud-iac-state-dynamodb-lock
+
+iam:
+  role_name: IacDeployRole
+  terraform_user_name: github-ci-runner
+
+tags:
+  Owner: Platform
+  Project: CloudNeutral

--- a/config/xzerolab/sit/aws-cloud/accounts/bootstrap.yaml
+++ b/config/xzerolab/sit/aws-cloud/accounts/bootstrap.yaml
@@ -1,0 +1,17 @@
+region: ap-northeast-1
+environment: bootstrap
+
+account_name: xzerolab
+account_id: 950604983695
+
+state:
+  bucket_name: aws-cloud-iac-state
+  dynamodb_table_name: aws-cloud-iac-state-dynamodb-lock
+
+iam:
+  role_name: IacDeployRole
+  terraform_user_name: github-ci-runner
+
+tags:
+  Owner: Platform
+  Project: CloudNeutral

--- a/config/xzerolab/sit/aws-cloud/accounts/dev-landingzone.yaml
+++ b/config/xzerolab/sit/aws-cloud/accounts/dev-landingzone.yaml
@@ -1,0 +1,9 @@
+region: "ap-northeast-1"
+account_id: "950604983695"
+
+landingzone:
+  console_mode: "readonly"     # 可选：deny / readonly
+  enable_risp_controls: true   # 限制 RI/SP 购买
+  enable_root_limited: true    # 限制 root API
+  enable_mfa_enforce: true     # 强制 MFA
+

--- a/config/xzerolab/sit/aws-cloud/accounts/dev.yaml
+++ b/config/xzerolab/sit/aws-cloud/accounts/dev.yaml
@@ -1,0 +1,19 @@
+account_id: 950604983695
+name: dev
+environment: dev
+
+region: ap-northeast-1
+
+role_to_assume: "arn:aws:iam::950604983695:role/IacDeployRole"
+logging_bucket: org-dev-logs
+shared_vpc_account: "950604983695"   # 单账号，所以保持一致
+
+tags:
+  Environment: dev
+  Owner: Platform
+  CostCenter: "DEV"
+  Project: CloudNeutral
+
+backend:
+  bucket: aws-cloud-iac-state
+  dynamodb_table: aws-cloud-iac-state-dynamodb-lock

--- a/config/xzerolab/sit/aws-cloud/provider_backend.yaml
+++ b/config/xzerolab/sit/aws-cloud/provider_backend.yaml
@@ -1,0 +1,61 @@
+defaults:
+  terraform_required_version: ">= 1.2"
+  aws_provider_version: "~> 5.92.0"
+  session_name: "TerraformDevSession"
+
+modules:
+  dev:
+    account: dev
+    backend:
+      key: "account/dev/core/terraform.tfstate"
+
+  dev-alb:
+    account: dev
+    backend:
+      key: "account/dev/alb/terraform.tfstate"
+
+  dev-ec2:
+    account: dev
+    backend:
+      key: "account/dev/ec2/terraform.tfstate"
+
+  dev-kafka:
+    account: dev
+    backend:
+      key: "account/dev/kafka/terraform.tfstate"
+
+  dev-landingzone:
+    account: dev
+    backend:
+      key: "bootstrap/dev-landingzone/terraform.tfstate"
+
+  dev-nlb:
+    account: dev
+    backend:
+      key: "account/dev/nlb/terraform.tfstate"
+
+  dev-object:
+    account: dev
+    component_dir: s3
+    backend:
+      key: "account/dev/s3/terraform.tfstate"
+
+  dev-rds:
+    account: dev
+    backend:
+      key: "account/dev/rds/terraform.tfstate"
+
+  dev-redis:
+    account: dev
+    backend:
+      key: "account/dev/redis/terraform.tfstate"
+
+  dev-role:
+    account: dev
+    backend:
+      key: "account/dev/iam/terraform.tfstate"
+
+  dev-vpc:
+    account: dev
+    backend:
+      key: "account/dev/vpc/terraform.tfstate"

--- a/config/xzerolab/sit/aws-cloud/resources/dev-alb/alb.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/dev-alb/alb.yaml
@@ -1,0 +1,19 @@
+name_prefix: "dev-alb"
+
+vpc_id: "vpc-0d0d8d822fa215104"
+
+subnet_ids:
+  - "subnet-0c370f7ff7311388e"
+  - "subnet-0b609b5773fe957fa"
+
+listeners:
+  - port: 80
+    protocol: "HTTP"
+    target_group_port: 80
+    target_group_protocol: "HTTP"
+
+  - port: 443
+    protocol: "HTTPS"
+    certificate_arn: "arn:aws:acm:ap-northeast-1:xxxx:certificate/xxxx-xxxx"
+    target_group_port: 443
+    target_group_protocol: "HTTP"

--- a/config/xzerolab/sit/aws-cloud/resources/dev-kafka/msk.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/dev-kafka/msk.yaml
@@ -1,0 +1,16 @@
+name_prefix: "dev-kafka"
+
+kafka_version: "3.6.0"
+
+brokers:
+  instance_type: "kafka.t3.small"
+  number_of_broker_nodes: 2
+
+ebs:
+  volume_size: 50
+
+vpc_id: "vpc-0d0d8d822fa215104"
+
+subnet_ids:
+  - "subnet-0c370f7ff7311388e"
+  - "subnet-0b609b5773fe957fa"

--- a/config/xzerolab/sit/aws-cloud/resources/dev-nlb/nlb.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/dev-nlb/nlb.yaml
@@ -1,0 +1,13 @@
+name_prefix: "dev-nlb"
+
+vpc_id: "vpc-0d0d8d822fa215104"
+
+subnet_ids:
+  - "subnet-0c370f7ff7311388e"
+  - "subnet-0b609b5773fe957fa"
+
+listeners:
+  - port: 80
+    protocol: "TCP"
+    target_group_port: 80
+    target_group_protocol: "TCP"

--- a/config/xzerolab/sit/aws-cloud/resources/dev-object/bucket.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/dev-object/bucket.yaml
@@ -1,0 +1,10 @@
+bucket_name: "svc-plus-dev-objects"
+
+# 是否开启版本管理（默认建议开启）
+enable_versioning: true
+
+# 是否启用加密，之后如果你想加 KMS 可以扩展
+enable_encryption: false
+
+# Public Access Block（通常建议保持 true）
+block_public_access: true

--- a/config/xzerolab/sit/aws-cloud/resources/dev-rds/rds.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/dev-rds/rds.yaml
@@ -1,0 +1,33 @@
+name_prefix: "dev-rds"
+
+engine: "postgres"
+engine_version: "16.1"
+instance_class: "db.t3.micro"
+
+username: "admin"
+password: "StrongPassword123"
+
+allocated_storage: 20
+max_allocated_storage: 100
+
+multi_az: false
+
+publicly_accessible: false
+
+subnet_ids:
+  - "subnet-0996ad2f8e8f96445"
+  - "subnet-0eaa450d1bb6f65be"
+
+vpc_security_group_ids:
+  - "sg-0ebfd69a09f87af4d"
+
+parameters:
+  - name: "log_min_duration_statement"
+    value: "1000"
+  - name: "log_statement"
+    value: "ddl"
+
+tags:
+  Environment: "dev"
+  Owner: "Platform"
+

--- a/config/xzerolab/sit/aws-cloud/resources/dev-redis/redis.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/dev-redis/redis.yaml
@@ -1,0 +1,13 @@
+name_prefix: "dev-redis"
+
+engine_version: "7.0"
+node_type: "cache.t3.micro"
+num_cache_nodes: 1
+
+subnet_ids:
+  - "subnet-xxxxxx"
+  - "subnet-yyyyyy"
+
+security_group_ids:
+  - "sg-xxxxxx"
+

--- a/config/xzerolab/sit/aws-cloud/resources/ec2/dev.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/ec2/dev.yaml
@@ -1,0 +1,26 @@
+name_prefix: "dev-ec2"
+
+vpc_id: "vpc-06e1d6dab47b1d35f"
+subnet_id: "subnet-06859ec23046f4556"
+
+instance:
+  type: "t3.micro"
+  ami: "ubuntu-2204"
+
+keypair:
+  name: "dev-key"
+  public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDEsuS135lzjVvlH2iNrKz23lDFr7b686xs4d2HINP2glFPmgkgx1D6Dqwisb1UbhWHZmUUzRxXeNlE8fiaO0TXN/C0dsdUxgopnQRyakcA+gfJqqb38Syx8eqdC7mQy9ygOf763dWm6d/SYZ8WgNWLldk4QF9DiZOW9K22DMtY4/1Cqe/YE/WGpOMVr9T9BwvmOjarjWp2OPbx6RVlSOd735Mze5X+cJ9QqdLaisCiSoJ3j9S6dulcxm+7ghPfATvxlJyZWSrRrVqnmV45lPbeuUHlIEyuK1PK2MS6NtUP03ZhdRYJQKZLECpR5xAO/BliOtDdRornvHV1gutYD8/n3IS8sRVzYPvN9DuOhzBnBQUgciu2++R8zMfdVoH7mSbsE8u++vMcBk3UJ1Op0Ct+trl2bsnue96cAnoiII08JKwAaczD5uZIGhdkGV8zKnChNCjzCxP0i4PV/MYW04eWmH+E8G81zq4ZsvrvPYmilBbRrkwHvvbPba3SSb2F2As= shenlan@shenlandeMacBook-Air-2.local"
+
+security_group:
+  name: "dev-ec2-sg"
+  ssh_cidr: "0.0.0.0/0"
+  additional_ingress:
+    - port: 80
+      protocol: tcp
+      cidr: "0.0.0.0/0"
+    - port: 443
+      protocol: tcp
+      cidr: "0.0.0.0/0"
+    - port: 1443
+      protocol: tcp
+      cidr: "0.0.0.0/0"

--- a/config/xzerolab/sit/aws-cloud/resources/vpc/dev.yaml
+++ b/config/xzerolab/sit/aws-cloud/resources/vpc/dev.yaml
@@ -1,0 +1,19 @@
+name_prefix: "dev-vpc"
+
+vpc_cidr: "10.0.0.0/16"
+
+public_subnets:
+  - cidr: "10.0.1.0/24"
+    az: "ap-northeast-1a"
+    name: "dev-public-1"
+  - cidr: "10.0.2.0/24"
+    az: "ap-northeast-1c"
+    name: "dev-public-2"
+
+private_subnets:
+  - cidr: "10.0.11.0/24"
+    az: "ap-northeast-1a"
+    name: "dev-private-1"
+  - cidr: "10.0.12.0/24"
+    az: "ap-northeast-1c"
+    name: "dev-private-2"

--- a/config/xzerolab/sit/gcp-cloud/accounts/bootstrap.yaml
+++ b/config/xzerolab/sit/gcp-cloud/accounts/bootstrap.yaml
@@ -1,0 +1,20 @@
+project_id: xzerolab-480008
+environment: bootstrap
+
+state:
+  bucket_name: gcp-cloud-iac-state
+  bucket_location: US
+  firestore_location: us-central1
+
+iam:
+  deployer_identity: github-ci-runner        # 对应 AWS 的 IAM User：github-ci-runner
+  deploy_role_name: IacDeployRole      # 对应 AWS 的 IAM Role：TerraformDeployRole
+
+  deploy_role_bindings:
+    - roles/resourcemanager.projectIamAdmin
+    - roles/storage.admin
+    - roles/compute.admin
+
+tags:
+  Owner: Platform
+  Project: CloudNeutral

--- a/config/xzerolab/sit/gcp-cloud/accounts/dev-landingzone.yaml
+++ b/config/xzerolab/sit/gcp-cloud/accounts/dev-landingzone.yaml
@@ -1,0 +1,13 @@
+project_id: "modern-app-dev"
+region: "us-central1"
+
+landingzone:
+  enable_default_network_cleanup: true
+  enable_oslogin_enforce: true
+  enable_audit_logging: true
+  enabled_services:
+    - compute.googleapis.com
+    - iam.googleapis.com
+    - cloudresourcemanager.googleapis.com
+    - logging.googleapis.com
+    - servicemanagement.googleapis.com

--- a/config/xzerolab/sit/gcp-cloud/accounts/dev.yaml
+++ b/config/xzerolab/sit/gcp-cloud/accounts/dev.yaml
@@ -1,0 +1,18 @@
+project_id: "xzerolab-480008"
+project_number: "123456789012"
+name: dev
+environment: dev
+
+region: "us-central1"
+impersonate_service_account: "terraform-deployer@modern-app-dev.iam.gserviceaccount.com"
+logging_bucket: "org-dev-logs"
+shared_vpc_project: "modern-shared-vpc-dev"
+
+labels:
+  environment: dev
+  owner: Platform
+  costcenter: "DEV"
+  Project: CloudNeutral
+
+backend:
+  bucket: gcp-cloud-iac-state

--- a/config/xzerolab/sit/gcp-cloud/resources/dev-alb/alb.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/dev-alb/alb.yaml
@@ -1,0 +1,7 @@
+project_id: "modern-app-dev"
+name: "dev-alb"
+bucket_name: "dev-alb-static-site"
+
+backend:
+  cache_enabled: true
+  bucket_location: "US"

--- a/config/xzerolab/sit/gcp-cloud/resources/dev-kafka/msk.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/dev-kafka/msk.yaml
@@ -1,0 +1,6 @@
+project_id: "modern-app-dev"
+topic: "dev-orders"
+subscription: "dev-orders-sub"
+
+message_retention_days: 7
+push_endpoint: "https://example.dev.internal/events"

--- a/config/xzerolab/sit/gcp-cloud/resources/dev-nlb/nlb.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/dev-nlb/nlb.yaml
@@ -1,0 +1,7 @@
+project_id: "modern-app-dev"
+name: "dev-nlb"
+network: "projects/modern-app-dev/global/networks/dev-vpc"
+subnet: "projects/modern-app-dev/regions/us-central1/subnetworks/dev-public-1"
+
+port: 443
+zone: "us-central1-a"

--- a/config/xzerolab/sit/gcp-cloud/resources/dev-object/bucket.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/dev-object/bucket.yaml
@@ -1,0 +1,7 @@
+project_id: "modern-app-dev"
+name: "dev-app-artifacts"
+location: "US"
+storage_class: "STANDARD"
+
+versioning: true
+retention_days: 30

--- a/config/xzerolab/sit/gcp-cloud/resources/dev-rds/rds.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/dev-rds/rds.yaml
@@ -1,0 +1,9 @@
+project_id: "modern-app-dev"
+name: "dev-orders-db"
+database_version: "POSTGRES_15"
+tier: "db-g1-small"
+region: "us-central1"
+
+backup_configuration:
+  enabled: true
+  point_in_time_recovery: true

--- a/config/xzerolab/sit/gcp-cloud/resources/dev-redis/redis.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/dev-redis/redis.yaml
@@ -1,0 +1,9 @@
+project_id: "modern-app-dev"
+name: "dev-cache"
+region: "us-central1"
+tier: "STANDARD_HA"
+memory_size_gb: 2
+
+persistence_config:
+  mode: "RDB"
+  rdb_snapshot_period: "SIX_HOURS"

--- a/config/xzerolab/sit/gcp-cloud/resources/ec2/dev.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/ec2/dev.yaml
@@ -1,0 +1,35 @@
+project_id: "modern-app-dev"
+name_prefix: "dev-compute"
+zone: "us-central1-a"
+machine_type: "e2-medium"
+image: "ubuntu-2204-lts"
+
+network_self_link: "projects/modern-app-dev/global/networks/dev-vpc"
+subnet_self_link: "projects/modern-app-dev/regions/us-central1/subnetworks/dev-private-1"
+
+metadata:
+  ssh_keys:
+    - "devops:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCquf7APpVdazv1xC5loENKQyWrOOI+yeP13jsMoPTFr/7A1za2cdHVv75D4f0ZePuvxi+3S4Nf5eCn5xsnzuvnvV3rxJ7bC3SbgsVA4STpdkElWJxz/TcgE7kMWSyGfNa5+07Ljjq2+g7fqFfEGP7x3+NFuTIvdy7OOhHPK29m8OIgHtO+X7NWDzSIe4lmxOfo9hQLU5qkWWmY+FXuDLO06mu5a1ruSlG4/lKQ77lr6E5k6I7dpFIlzPzCYcLOQDZ80GLk6e2ukgIFzOxplnnmnIBm9saKzNhxZ9V0sbOYu4lWuxpkzrQJBSyiR7+A8mE4xboz85vPX5dHRXc5bBLF6oVT/GH1+8eMqNygwdqbSKBzR5V1Z1LvJfHpJQmmH8T0U/ax7Rz1tfJbdSWJ9sFvVOuNKs1oo0WM6E/j1MMmwzZg1JYwl6GDaFpyUp92wjSyFcJTNfn1Fx5t8o0HpcQNVdLMeOHlqlPRkYfED1x4hlEZJu0fD/8IvcaUsdluyMFSxhE= devops@example.com"
+
+boot_disk_gb: 30
+tags:
+  - dev-ssh
+  - dev-web
+
+firewall_rules:
+  - name: "dev-ssh"
+    direction: ingress
+    ranges:
+      - "0.0.0.0/0"
+    protocols:
+      tcp: [22]
+    target_tags:
+      - dev-ssh
+  - name: "dev-web"
+    direction: ingress
+    ranges:
+      - "0.0.0.0/0"
+    protocols:
+      tcp: [80, 443]
+    target_tags:
+      - dev-web

--- a/config/xzerolab/sit/gcp-cloud/resources/vpc/dev.yaml
+++ b/config/xzerolab/sit/gcp-cloud/resources/vpc/dev.yaml
@@ -1,0 +1,14 @@
+project_id: "modern-app-dev"
+network_name: "dev-vpc"
+
+subnets:
+  - name: "dev-public-1"
+    ip_cidr_range: "10.0.1.0/24"
+    region: "us-central1"
+  - name: "dev-private-1"
+    ip_cidr_range: "10.0.11.0/24"
+    region: "us-central1"
+
+firewall_tags:
+  ssh: "dev-ssh"
+  web: "dev-web"


### PR DESCRIPTION
## Summary
- add xzerolab SIT configuration for AWS, GCP, and Vultr by merging terraform-hcl-standard templates
- promote shared bootstrap account configuration to config/bootstrap.yaml
- document the recommended config directory structure and the applied layout for this repo

## Testing
- not run (configuration and documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bab0f81488332aa3a2c648d8aea1c)