### PR TITLE
Refine GitHub Actions OIDC role policy rendering

### DIFF
--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/README.md
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/README.md
@@ -1,0 +1,36 @@
+# AWS Bootstrap Identity (Terraform / GitHub Actions OIDC)
+
+此目录在原有 Terraform AK/SK 引导身份的基础上，新增 GitHub Actions OIDC 专用角色，便于无长生命周期凭证的 IaC 自动化。若 OIDC 服务不可用，仍可使用原有 Terraform IAM User + AssumeRole 路径作为应急逃逸出口。
+
+## 资源概览
+
+- `aws_iam_openid_connect_provider.github_actions`：GitHub Actions 公共 OIDC Provider（`https://token.actions.githubusercontent.com`）。
+- `aws_iam_role.github_actions_deploy_role`：供 GitHub Actions 通过 OIDC 假设的角色，限制到仓库 `cloud-neutral-toolkit/Modern-Container-Application-Reference-Architecture` 的 `main` 分支。
+- `aws_iam_role_policy_attachment.github_actions_deploy_role_admin`：示例使用 AWS 托管策略 `AdministratorAccess`（实际项目请收敛至 S3 state / DynamoDB lock 所需的最小权限）。
+
+## Terraform 输出
+
+- `github_actions_oidc_provider_arn`：GitHub Actions OIDC Provider ARN。
+- `github_actions_deploy_role_arn`：GitHub Actions OIDC AssumeRole ARN。
+- 兼容保留：`iam_role_arn`（Terraform Deploy Role）、`terraform_user_name`（Terraform IAM User）。
+
+## GitHub Actions 配置要点
+
+Workflow 需要的权限：
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+```
+
+示例步骤（仅示例，不生成 workflow 文件）：
+
+```yaml
+- uses: aws-actions/configure-aws-credentials@v4
+  with:
+    role-to-assume: <terraform output: github_actions_deploy_role_arn>
+    aws-region: ap-northeast-1
+```
+
+可根据需要在后续步骤执行 Terraform CLI，使用 OIDC 方式取代长期 AK/SK。若 OIDC 服务异常，可切回输出的 `iam_role_arn` 与 `terraform_user_name` 路径。

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/outputs.tf
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/outputs.tf
@@ -7,3 +7,13 @@ output "terraform_user_name" {
   value       = var.create_user ? aws_iam_user.terraform_user[0].name : local.terraform_user_name
   description = "Terraform IAM User"
 }
+
+output "github_actions_oidc_provider_arn" {
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+  description = "OIDC provider ARN for GitHub Actions"
+}
+
+output "github_actions_deploy_role_arn" {
+  value       = aws_iam_role.github_actions_deploy_role.arn
+  description = "IAM role ARN assumed by GitHub Actions via OIDC"
+}

--- a/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/policies/github-actions-deploy-assume-role.json
+++ b/iac-template/terraform-hcl-standard/aws-cloud/bootstrap/identity/policies/github-actions-deploy-assume-role.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${oidc_provider_arn}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:sub": "repo:cloud-neutral-toolkit/Modern-Container-Application-Reference-Architecture:ref:refs/heads/main",
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- render the GitHub Actions OIDC assume-role policy from a template file using override_policy_documents
- add a dedicated policy template for the GitHub Actions deployment role

## Testing
- `terraform fmt` *(fails: terraform not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bba9914b483329ec62caa72c08dc4)