### PR TITLE
Make Check IaaS Ready workflow configurable

### DIFF
--- a/.github/workflows/check-iaas-ready.yaml
+++ b/.github/workflows/check-iaas-ready.yaml
@@ -1,0 +1,53 @@
+name: Check IaaS Ready
+
+on:
+  workflow_dispatch:
+    inputs:
+      workflows:
+        description: "Comma-separated workflow filenames to check"
+        required: true
+        type: string
+      branch:
+        description: "Branch to check"
+        default: main
+        type: string
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check workflows status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOWS: ${{ inputs.workflows }}
+          BRANCH: ${{ inputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          IFS=',' read -ra WF_LIST <<< "$WORKFLOWS"
+
+          for WF in "${WF_LIST[@]}"; do
+            WF=$(echo "$WF" | xargs)
+            echo "🔍 Checking workflow: $WF"
+
+            RUN=$(gh api \
+              repos/$REPO/actions/workflows/$WF/runs \
+              -F branch="$BRANCH" \
+              -F per_page=1 \
+              --jq '.workflow_runs[0]')
+
+            if [ "$RUN" = "null" ]; then
+              echo "❌ No runs found for $WF"
+              exit 1
+            fi
+
+            STATUS=$(echo "$RUN" | jq -r '.conclusion')
+
+            if [ "$STATUS" != "success" ]; then
+              echo "❌ $WF latest run is not successful: $STATUS"
+              exit 1
+            fi
+
+            echo "✅ $WF is ready"
+          done


### PR DESCRIPTION
## Summary
- redesign the Check IaaS Ready workflow to accept configurable workflow filenames and branch
- add GitHub API-based validation of latest workflow run success for readiness status

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bccc21e608332a995da5ed3a60b5c)