### PR TITLE
Align CI paths with terraform-hcl-standard layout

### DIFF
--- a/.github/workflows/iac-pipeline-aws-global-account-matrix.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-account-matrix.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/iac-pipeline-aws-account-matrix.yaml'
-      - 'iac-template/terraform-hcl-standard/aws-cloud/component/vpc/**'
-      - 'iac-template/terraform-hcl-standard/aws-cloud/component/role/**'
+      - 'terraform-hcl-standard/aws-cloud/component/vpc/**'
+      - 'terraform-hcl-standard/aws-cloud/component/role/**'
   workflow_dispatch:
     inputs:
       deploy_action:
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component/
+  BASE_DIR: terraform-hcl-standard/aws-cloud/component/
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   CONFIG_FILES: |
     config/xzerolab/sit/aws-cloud/account/accounts.yaml
@@ -56,7 +56,7 @@ import os
 import sys
 from pathlib import Path
 
-utils_dir = Path("iac-template/terraform-hcl-standard/utils").resolve()
+utils_dir = Path("terraform-hcl-standard/utils").resolve()
 sys.path.insert(0, str(utils_dir))
 
 from config_loader import load_account_credentials

--- a/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/iac-pipeline-aws-global-bootstrap.yaml'
-      - 'iac-template/terraform-hcl-standard/aws-cloud/bootstrap/**'
+      - 'terraform-hcl-standard/aws-cloud/bootstrap/**'
   workflow_dispatch:
     inputs:
       deploy_action:
@@ -18,7 +18,7 @@ on:
         default: plan
 
 env:
-  TG_ROOT: iac-template/terraform-hcl-standard/aws-cloud/bootstrap
+  TG_ROOT: terraform-hcl-standard/aws-cloud/bootstrap
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   TG_VERSION: 0.67.14
 
@@ -38,7 +38,7 @@ jobs:
           - S3: create remote state bucket (versioned + SSE + public access block)
           - DynamoDB: create state lock table with encryption + PITR
 
-          Terragrunt orchestrates state → lock → identity. Resource names and regions follow iac-template/terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml.
+          Terragrunt orchestrates state → lock → identity. Resource names and regions follow terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml.
           SUMMARY
 
       - uses: hashicorp/setup-terraform@v3
@@ -60,7 +60,7 @@ jobs:
       - name: Force Destroy Bootstrap Resources
         if: env.DEPLOY_ACTION == 'destroy'
         env:
-          CONFIG_PATH: iac-template/terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml
+          CONFIG_PATH: terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml
         run: |
           ./scripts/aws-bootstrap-force-destroy.sh
 

--- a/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
     paths:
-      - 'iac-template/terraform-hcl-standard/aws-cloud/**'
+      - 'terraform-hcl-standard/aws-cloud/**'
       - '.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml'
   pull_request:
     branches: [main]
@@ -23,7 +23,7 @@ on:
         default: 'true'
 
 env:
-  TF_WORKDIR: iac-template/terraform-hcl-standard/aws-cloud
+  TF_WORKDIR: terraform-hcl-standard/aws-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   AWS_REGION: ap-northeast-1
   AWS_ROLE_ARN: arn:aws:iam::950604983695:role/GithubAction_IAC_Deploy_Role

--- a/.github/workflows/iac-pipeline-aws-global-resources-matrix.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-resources-matrix.yaml
@@ -6,8 +6,8 @@ on:
     paths:
     paths:
       - '.github/workflows/iac-pipeline-aws-resources-matrix.yaml'
-      - 'iac-template/terraform-hcl-standard/aws-cloud/component/ec2/**'
-      - 'iac-template/terraform-hcl-standard/aws-cloud/component/s3/**'
+      - 'terraform-hcl-standard/aws-cloud/component/ec2/**'
+      - 'terraform-hcl-standard/aws-cloud/component/s3/**'
   workflow_dispatch:
     inputs:
       deploy_action:
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/aws-cloud/component
+  BASE_DIR: terraform-hcl-standard/aws-cloud/component
   AWS_REGION: ap-northeast-1
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   AWS_ROLE_ARN: arn:aws:iam::950604983695:role/GithubAction_IAC_Deploy_Role

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-account-matrix.yaml
@@ -3,9 +3,9 @@ name: IAC Pipeline Alicloud Account/VPC Matrix
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/ali-cloud/modules/vpc/**'
-      - 'iac-template/terraform-hcl-standard/ali-cloud/modules/ram/**'
-      - 'iac-template/terraform-hcl-standard/ali-cloud/envs/dev/**'
+      - 'terraform-hcl-standard/ali-cloud/modules/vpc/**'
+      - 'terraform-hcl-standard/ali-cloud/modules/ram/**'
+      - 'terraform-hcl-standard/ali-cloud/envs/dev/**'
       - '.github/workflows/terraform-standard-iac-pipeline-alicloud-account-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -15,7 +15,7 @@ on:
         default: 'true'
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/ali-cloud/envs
+  BASE_DIR: terraform-hcl-standard/ali-cloud/envs
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
   ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
 

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-bootstrap.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/ali-cloud/bootstrap/**'
+      - 'terraform-hcl-standard/ali-cloud/bootstrap/**'
       - '.github/workflows/terraform-standard-iac-pipeline-alicloud-bootstrap.yaml'
   pull_request:
   workflow_dispatch:
@@ -18,7 +18,7 @@ on:
         default: plan
 
 env:
-  TF_WORKDIR: iac-template/terraform-hcl-standard/ali-cloud/bootstrap
+  TF_WORKDIR: terraform-hcl-standard/ali-cloud/bootstrap
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
 
@@ -42,7 +42,7 @@ jobs:
           - lock: create Table Store instance/table for Terraform state locking
           - identity: provision RAM role/user plus access keys for automation
 
-          Resource names and defaults follow iac-template/terraform-hcl-standard/ali-cloud/bootstrap.
+          Resource names and defaults follow terraform-hcl-standard/ali-cloud/bootstrap.
           SUMMARY
 
       - uses: hashicorp/setup-terraform@v3
@@ -80,7 +80,7 @@ jobs:
         if: env.DEPLOY_ACTION == 'apply'
         with:
           name: outputs-${{ matrix.target }}
-          path: iac-template/terraform-hcl-standard/ali-cloud/outputs_${{ matrix.target }}.json
+          path: terraform-hcl-standard/ali-cloud/outputs_${{ matrix.target }}.json
           retention-days: 30
 
   aggregate:

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-landingzone-baseline.yaml
@@ -3,7 +3,7 @@ name: Alicloud LandingZone Baseline
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/ali-cloud/**'
+      - 'terraform-hcl-standard/ali-cloud/**'
       - '.github/workflows/terraform-standard-iac-pipeline-alicloud-landingzone-baseline.yaml'
   pull_request:
     branches: [main]
@@ -21,7 +21,7 @@ on:
         default: 'true'
 
 env:
-  TF_WORKDIR: iac-template/terraform-hcl-standard/ali-cloud
+  TF_WORKDIR: terraform-hcl-standard/ali-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
 

--- a/.github/workflows/terraform-standard-iac-pipeline-alicloud-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-alicloud-resources-matrix.yaml
@@ -3,8 +3,8 @@ name: IAC Pipeline Alicloud Resources Matrix
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/ali-cloud/modules/**'
-      - 'iac-template/terraform-hcl-standard/ali-cloud/envs/dev/**'
+      - 'terraform-hcl-standard/ali-cloud/modules/**'
+      - 'terraform-hcl-standard/ali-cloud/envs/dev/**'
       - '.github/workflows/terraform-standard-iac-pipeline-alicloud-resources-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -14,7 +14,7 @@ on:
         default: 'true'
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/ali-cloud/envs
+  BASE_DIR: terraform-hcl-standard/ali-cloud/envs
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
   ALICLOUD_REGION: ${{ secrets.ALICLOUD_REGION }}
 

--- a/.github/workflows/terraform-standard-iac-pipeline-gcp-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-gcp-account-matrix.yaml
@@ -3,8 +3,8 @@ name: IAC Pipeline GCP (Account/Project Matrix)
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/envs/dev-vpc/**'
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/envs/dev-role/**'
+      - 'terraform-hcl-standard/gcp-cloud/envs/dev-vpc/**'
+      - 'terraform-hcl-standard/gcp-cloud/envs/dev-role/**'
       - '.github/workflows/terraform-standard-iac-pipeline-gcp-account-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -14,7 +14,7 @@ on:
         default: 'true'
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/gcp-cloud/envs
+  BASE_DIR: terraform-hcl-standard/gcp-cloud/envs
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
 

--- a/.github/workflows/terraform-standard-iac-pipeline-gcp-global-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-gcp-global-bootstrap.yaml
@@ -7,8 +7,8 @@ concurrency:
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/bootstrap-gcs/**'
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/bootstrap-iam/**'
+      - 'terraform-hcl-standard/gcp-cloud/bootstrap-gcs/**'
+      - 'terraform-hcl-standard/gcp-cloud/bootstrap-iam/**'
       - '.github/workflows/terraform-standard-iac-pipeline-gcp-global-bootstrap.yaml'
   pull_request:
   workflow_dispatch:
@@ -19,7 +19,7 @@ on:
         default: plan
 
 env:
-  TF_WORKDIR: iac-template/terraform-hcl-standard/gcp-cloud
+  TF_WORKDIR: terraform-hcl-standard/gcp-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
           - Cloud Storage: create remote state bucket (versioned + uniform access + generation-based locking)
           - IAM: create Terraform bootstrap service account and bind elevated roles
 
-          Resource names and locations follow iac-template/terraform-hcl-standard/gcp-cloud/config/accounts/bootstrap.yaml.
+          Resource names and locations follow terraform-hcl-standard/gcp-cloud/config/accounts/bootstrap.yaml.
           SUMMARY
 
       - uses: hashicorp/setup-terraform@v3
@@ -64,7 +64,7 @@ jobs:
           import os
           from pathlib import Path
 
-          cfg_path = Path("iac-template/terraform-hcl-standard/gcp-cloud/config/accounts/bootstrap.yaml")
+          cfg_path = Path("terraform-hcl-standard/gcp-cloud/config/accounts/bootstrap.yaml")
           cfg = yaml.safe_load(cfg_path.read_text())
 
           env_path = Path(os.environ["GITHUB_ENV"])
@@ -159,7 +159,7 @@ jobs:
         if: env.DEPLOY_ACTION == 'apply'
         with:
           name: outputs-${{ matrix.target }}
-          path: iac-template/terraform-hcl-standard/gcp-cloud/outputs_${{ matrix.target }}.json
+          path: terraform-hcl-standard/gcp-cloud/outputs_${{ matrix.target }}.json
           retention-days: 30
 
   aggregate:

--- a/.github/workflows/terraform-standard-iac-pipeline-gcp-global-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-gcp-global-landingzone-baseline.yaml
@@ -3,7 +3,7 @@ name: GCP Cloud LandingZone Baseline
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/**'
+      - 'terraform-hcl-standard/gcp-cloud/**'
       - '.github/workflows/terraform-standard-iac-pipeline-gcp-global-landingzone-baseline.yaml'
   pull_request:
     branches: [main]
@@ -21,7 +21,7 @@ on:
         default: 'true'
 
 env:
-  TF_WORKDIR: iac-template/terraform-hcl-standard/gcp-cloud
+  TF_WORKDIR: terraform-hcl-standard/gcp-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
 
   # -------------------------------

--- a/.github/workflows/terraform-standard-iac-pipeline-gcp-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-gcp-resources-matrix.yaml
@@ -3,8 +3,8 @@ name: IAC Pipeline GCP Resources Matrix
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/envs/dev-object/**'
-      - 'iac-template/terraform-hcl-standard/gcp-cloud/envs/dev-ec2/**'
+      - 'terraform-hcl-standard/gcp-cloud/envs/dev-object/**'
+      - 'terraform-hcl-standard/gcp-cloud/envs/dev-ec2/**'
       - '.github/workflows/terraform-standard-iac-pipeline-gcp-resources-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -14,7 +14,7 @@ on:
         default: 'true'
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/gcp-cloud/envs
+  BASE_DIR: terraform-hcl-standard/gcp-cloud/envs
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
 

--- a/.github/workflows/terraform-standard-iac-pipeline-vultr-account-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-vultr-account-matrix.yaml
@@ -3,9 +3,9 @@ name: IAC Pipeline Vultr VPS Account/VPC Matrix
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/vpc/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/iam/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/envs/dev/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/vpc/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/iam/**'
+      - 'terraform-hcl-standard/vultr-vps/envs/dev/**'
       - '.github/workflows/terraform-standard-iac-pipeline-vultr-account-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -15,7 +15,7 @@ on:
         default: 'true'
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/vultr-vps/envs
+  BASE_DIR: terraform-hcl-standard/vultr-vps/envs
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
 
 jobs:

--- a/.github/workflows/terraform-standard-iac-pipeline-vultr-global-bootstrap.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-vultr-global-bootstrap.yaml
@@ -7,9 +7,9 @@ concurrency:
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/vultr-vps/bootstrap-object-storage/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/bootstrap-iam/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/config/**'
+      - 'terraform-hcl-standard/vultr-vps/bootstrap-object-storage/**'
+      - 'terraform-hcl-standard/vultr-vps/bootstrap-iam/**'
+      - 'terraform-hcl-standard/vultr-vps/config/**'
       - '.github/workflows/terraform-standard-iac-pipeline-vultr-global-bootstrap.yaml'
   workflow_dispatch:
     inputs:
@@ -19,7 +19,7 @@ on:
         default: plan
 
 env:
-  TF_ROOT: iac-template/terraform-hcl-standard/vultr-vps
+  TF_ROOT: terraform-hcl-standard/vultr-vps
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
 
 jobs:

--- a/.github/workflows/terraform-standard-iac-pipeline-vultr-global-landingzone-baseline.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-vultr-global-landingzone-baseline.yaml
@@ -7,8 +7,8 @@ concurrency:
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/vpc/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/config/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/vpc/**'
+      - 'terraform-hcl-standard/vultr-vps/config/**'
       - '.github/workflows/terraform-standard-iac-pipeline-vultr-global-landingzone-baseline.yaml'
   workflow_dispatch:
     inputs:
@@ -19,7 +19,7 @@ on:
         default: plan
 
 env:
-  TF_ROOT: iac-template/terraform-hcl-standard/vultr-vps/modules/vpc
+  TF_ROOT: terraform-hcl-standard/vultr-vps/modules/vpc
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
 
 jobs:

--- a/.github/workflows/terraform-standard-iac-pipeline-vultr-global-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-vultr-global-resources-matrix.yaml
@@ -7,11 +7,11 @@ concurrency:
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/vultr-vps/envs/dev/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/compute/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/storage/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/data_store/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/config/**'
+      - 'terraform-hcl-standard/vultr-vps/envs/dev/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/compute/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/storage/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/data_store/**'
+      - 'terraform-hcl-standard/vultr-vps/config/**'
       - '.github/workflows/terraform-standard-iac-pipeline-vultr-global-resources-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -21,7 +21,7 @@ on:
         default: plan
 
 env:
-  TF_ROOT: iac-template/terraform-hcl-standard/vultr-vps/envs
+  TF_ROOT: terraform-hcl-standard/vultr-vps/envs
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
 
 jobs:

--- a/.github/workflows/terraform-standard-iac-pipeline-vultr-resources-matrix.yaml
+++ b/.github/workflows/terraform-standard-iac-pipeline-vultr-resources-matrix.yaml
@@ -3,10 +3,10 @@ name: IAC Pipeline Vultr VPS Resources Matrix
 on:
   push:
     paths:
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/compute/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/storage/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/modules/data_store/**'
-      - 'iac-template/terraform-hcl-standard/vultr-vps/envs/dev/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/compute/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/storage/**'
+      - 'terraform-hcl-standard/vultr-vps/modules/data_store/**'
+      - 'terraform-hcl-standard/vultr-vps/envs/dev/**'
       - '.github/workflows/terraform-standard-iac-pipeline-vultr-resources-matrix.yaml'
   workflow_dispatch:
     inputs:
@@ -16,7 +16,7 @@ on:
         default: 'true'
 
 env:
-  BASE_DIR: iac-template/terraform-hcl-standard/vultr-vps/envs
+  BASE_DIR: terraform-hcl-standard/vultr-vps/envs
   DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -40,11 +40,11 @@ coverage.xml
 *.tfstate
 *.tfstate.*
 # Generated Terraform provider/backend files for AWS cloud envs
-iac-template/terraform-hcl-standard/aws-cloud/envs/*/provider.tf
-iac-template/terraform-hcl-standard/aws-cloud/envs/*/backend.tf
+terraform-hcl-standard/aws-cloud/envs/*/provider.tf
+terraform-hcl-standard/aws-cloud/envs/*/backend.tf
 # Generated provider/backend files for component stacks
-iac-template/terraform-hcl-standard/aws-cloud/component/*/provider.tf
-iac-template/terraform-hcl-standard/aws-cloud/component/*/backend.tf
+terraform-hcl-standard/aws-cloud/component/*/provider.tf
+terraform-hcl-standard/aws-cloud/component/*/backend.tf
 
 # Ansible
 *.retry

--- a/scripts/aws-bootstrap-force-destroy.sh
+++ b/scripts/aws-bootstrap-force-destroy.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONFIG_PATH=${CONFIG_PATH:-iac-template/terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml}
+CONFIG_PATH=${CONFIG_PATH:-terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml}
 
 read TERRAFORM_USER ROLE_NAME STATE_BUCKET LOCK_TABLE AWS_REGION ACCOUNT_ID <<< "$(python - <<'PY'
 import yaml
 import os
 
-config_path = os.environ.get('CONFIG_PATH', 'iac-template/terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml')
+config_path = os.environ.get('CONFIG_PATH', 'terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml')
 
 with open(config_path, 'r') as f:
     cfg = yaml.safe_load(f)

--- a/scripts/notifications/notify-landingzone.sh
+++ b/scripts/notifications/notify-landingzone.sh
@@ -23,7 +23,7 @@ BODY_HTML=$(cat <<EOF
   <h2>🚀 AWS LandingZone Baseline Rollout Completed</h2>
   <p>The baseline deployment for <b>LandingZone Minimal</b> has successfully finished.</p>
   <p><b>Environment:</b> dev-landingzone<br/>
-     <b>Workdir:</b> iac-template/terraform-standard</p>
+     <b>Workdir:</b> terraform-hcl-standard/aws-cloud/envs/dev-landingzone</p>
 
   <p>This includes:</p>
   <ul>

--- a/terraform-hcl-standard/aws-cloud/bootstrap/README.md
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/README.md
@@ -26,7 +26,7 @@ Terragrunt `run-all` handles the ordering; no manual sequencing is required.
 ## How to Run with Terragrunt
 
 ```bash
-cd iac-template/terraform-hcl-standard/aws-cloud/bootstrap
+cd terraform-hcl-standard/aws-cloud/bootstrap
 
 # Plan everything in dependency order
 terragrunt run-all plan


### PR DESCRIPTION
## Summary
- align all cloud workflows to the terraform-hcl-standard directory layout so working directories resolve correctly
- update the bootstrap cleanup script and documentation to default to the current path structure
- refresh notification text and ignore rules to match the updated layout

## Testing
- Not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b5e629694833281646bb89f56b36f)