### PR TITLE
Support env override for AWS bootstrap config path

### DIFF
--- a/terraform-hcl-standard/aws-cloud/bootstrap/README.md
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/README.md
@@ -21,7 +21,7 @@ Terragrunt `run-all` handles the ordering; no manual sequencing is required.
 
 - **Data plane**: S3 bucket enforces AES256 SSE, public access block, and versioning. DynamoDB enables server-side encryption and PITR for forensic recovery.
 - **Control plane**: IAM policies are externalized in `identity/policies/*.json` and rendered via `aws_iam_policy_document` to keep Terraform code lean and auditable.
-- **Config source of truth**: The GitOps repo (`https://github.com/cloud-neutral-workshop/gitops.git`) stores `config/accounts/bootstrap.yaml`, defining canonical names, regions, and tags. Terragrunt reads it via `GITOPS_REPO_ROOT` (defaults to `../gitops` relative to this repo).
+- **Config source of truth**: The GitOps repo (`https://github.com/cloud-neutral-workshop/gitops.git`) stores `config/accounts/bootstrap.yaml`, defining canonical names, regions, and tags. Terragrunt reads it via `GITOPS_REPO_ROOT` (defaults to `../gitops` relative to this repo). Clone that repository locally or set `GITOPS_REPO_ROOT` to your desired path to keep configuration and modules separated. You can also override the config file path with `GITOPS_BOOTSTRAP_CONFIG` (for example, `config/xzerolab/sit/aws-cloud/account/bootstrap.yaml` inside the GitOps repo).
 
 ## How to Run with Terragrunt
 

--- a/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
@@ -16,9 +16,13 @@ locals {
     abspath("${get_parent_terragrunt_dir()}/../../../../../gitops")
   )
   config_root = "${local.gitops_repo_root}/config"
+  bootstrap_config_path = get_env(
+    "GITOPS_BOOTSTRAP_CONFIG",
+    "${local.config_root}/accounts/bootstrap.yaml"
+  )
 }
 
 inputs = {
-  bootstrap_config_path = "${local.config_root}/accounts/bootstrap.yaml"
+  bootstrap_config_path = local.bootstrap_config_path
   config_root           = local.gitops_repo_root
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
@@ -16,9 +16,13 @@ locals {
     abspath("${get_parent_terragrunt_dir()}/../../../../../gitops")
   )
   config_root = "${local.gitops_repo_root}/config"
+  bootstrap_config_path = get_env(
+    "GITOPS_BOOTSTRAP_CONFIG",
+    "${local.config_root}/accounts/bootstrap.yaml"
+  )
 }
 
 inputs = {
-  bootstrap_config_path = "${local.config_root}/accounts/bootstrap.yaml"
+  bootstrap_config_path = local.bootstrap_config_path
   config_root           = local.gitops_repo_root
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
@@ -12,9 +12,13 @@ locals {
     abspath("${get_parent_terragrunt_dir()}/../../../../../gitops")
   )
   config_root = "${local.gitops_repo_root}/config"
+  bootstrap_config_path = get_env(
+    "GITOPS_BOOTSTRAP_CONFIG",
+    "${local.config_root}/accounts/bootstrap.yaml"
+  )
 }
 
 inputs = {
-  bootstrap_config_path = "${local.config_root}/accounts/bootstrap.yaml"
+  bootstrap_config_path = local.bootstrap_config_path
   config_root           = local.gitops_repo_root
 }


### PR DESCRIPTION
## Summary
- allow overriding the bootstrap config file path via GITOPS_BOOTSTRAP_CONFIG in all bootstrap Terragrunt modules
- keep default GitOps root behavior while documenting an example path inside the external gitops repo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6bd7fdfc8332b4cb4c8d79da9cd2)