### PR TITLE
Add gitops_repo_name input to AWS workflows

### DIFF
--- a/.github/workflows/iac-pipeline-aws-global-account-matrix.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-account-matrix.yaml
@@ -13,6 +13,14 @@ on:
         type: choice
         options: [plan, apply, destroy]
         default: plan
+      gitops_repo_name:
+        description: "GitOps repository (URL or owner/repo)"
+        type: string
+        default: https://github.com/cloud-neutral-workshop/gitops.git
+      gitops_repo_ref:
+        description: "GitOps repo ref (branch/tag/sha) to use"
+        type: string
+        default: main
 
 permissions:
   id-token: write
@@ -25,6 +33,8 @@ env:
   CONFIG_FILES: |
     gitops/xzerolab/sit/aws-cloud/account/bootstrap.yaml
     gitops/xzerolab/sit/aws-cloud/resources/vpc.yaml
+  GITOPS_REPO_ROOT: gitops
+  GITOPS_BOOTSTRAP_CONFIG: gitops/xzerolab/sit/aws-cloud/account/bootstrap.yaml
 
 jobs:
   terraform:
@@ -44,8 +54,9 @@ jobs:
       - name: Checkout GitOps config
         uses: actions/checkout@v4
         with:
-          repository: cloud-neutral-workshop/gitops
-          path: gitops
+          repository: ${{ replace(replace(github.event.inputs.gitops_repo_name || 'https://github.com/cloud-neutral-workshop/gitops.git', 'https://github.com/', ''), '.git', '') }}
+          path: ${{ env.GITOPS_REPO_ROOT }}
+          ref: ${{ github.event.inputs.gitops_repo_ref || 'main' }}
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
@@ -16,11 +16,25 @@ on:
         type: choice
         options: [plan, apply, destroy]
         default: plan
+      gitops_repo_ref:
+        description: "GitOps repo ref (branch/tag/sha) to use"
+        type: string
+        default: main
+      gitops_repo_name:
+        description: "GitOps repository (URL or owner/repo)"
+        type: string
+        default: https://github.com/cloud-neutral-workshop/gitops.git
+      gitops_bootstrap_config:
+        description: "Path to bootstrap config file within the GitOps repo"
+        type: string
+        default: config/xzerolab/sit/aws-cloud/account/bootstrap.yaml
 
 env:
   TG_ROOT: terraform-hcl-standard/aws-cloud/bootstrap
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   TG_VERSION: 0.67.14
+  GITOPS_REPO_ROOT: gitops
+  GITOPS_BOOTSTRAP_CONFIG: ${{ github.event.inputs.gitops_bootstrap_config || 'config/xzerolab/sit/aws-cloud/account/bootstrap.yaml' }}
 
 jobs:
   bootstrap:
@@ -29,6 +43,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout GitOps config
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ replace(replace(github.event.inputs.gitops_repo_name || 'https://github.com/cloud-neutral-workshop/gitops.git', 'https://github.com/', ''), '.git', '') }}
+          path: ${{ env.GITOPS_REPO_ROOT }}
+          ref: ${{ github.event.inputs.gitops_repo_ref || 'main' }}
 
       - name: Document Bootstrap Scope
         run: |

--- a/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-landingzone-baseline.yaml
@@ -20,12 +20,21 @@ on:
         type: choice
         options: ['true', 'false']
         default: 'true'
+      gitops_repo_name:
+        description: "GitOps repository (URL or owner/repo)"
+        type: string
+        default: https://github.com/cloud-neutral-workshop/gitops.git
+      gitops_repo_ref:
+        description: "GitOps repo ref (branch/tag/sha) to use"
+        type: string
+        default: main
 
 env:
   TF_WORKDIR: terraform-hcl-standard/aws-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   AWS_REGION: ap-northeast-1
   AWS_ROLE_ARN: arn:aws:iam::950604983695:role/GithubAction_IAC_Deploy_Role
+  GITOPS_REPO_ROOT: gitops
 
 jobs:
   # -------------------------------------------------------
@@ -37,6 +46,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout GitOps config
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ replace(replace(github.event.inputs.gitops_repo_name || 'https://github.com/cloud-neutral-workshop/gitops.git', 'https://github.com/', ''), '.git', '') }}
+          path: ${{ env.GITOPS_REPO_ROOT }}
+          ref: ${{ github.event.inputs.gitops_repo_ref || 'main' }}
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/iac-pipeline-aws-global-resources-matrix.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-resources-matrix.yaml
@@ -13,6 +13,14 @@ on:
         type: choice
         options: [plan, apply, destroy]
         default: plan
+      gitops_repo_name:
+        description: "GitOps repository (URL or owner/repo)"
+        type: string
+        default: https://github.com/cloud-neutral-workshop/gitops.git
+      gitops_repo_ref:
+        description: "GitOps repo ref (branch/tag/sha) to use"
+        type: string
+        default: main
 
 permissions:
   id-token: write
@@ -23,6 +31,7 @@ env:
   AWS_REGION: ap-northeast-1
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   AWS_ROLE_ARN: arn:aws:iam::950604983695:role/GithubAction_IAC_Deploy_Role
+  GITOPS_REPO_ROOT: gitops
 
 jobs:
   terraform:
@@ -38,6 +47,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout GitOps config
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ replace(replace(github.event.inputs.gitops_repo_name || 'https://github.com/cloud-neutral-workshop/gitops.git', 'https://github.com/', ''), '.git', '') }}
+          path: ${{ env.GITOPS_REPO_ROOT }}
+          ref: ${{ github.event.inputs.gitops_repo_ref || 'main' }}
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/terraform-hcl-standard/aws-cloud/bootstrap/README.md
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/README.md
@@ -21,7 +21,7 @@ Terragrunt `run-all` handles the ordering; no manual sequencing is required.
 
 - **Data plane**: S3 bucket enforces AES256 SSE, public access block, and versioning. DynamoDB enables server-side encryption and PITR for forensic recovery.
 - **Control plane**: IAM policies are externalized in `identity/policies/*.json` and rendered via `aws_iam_policy_document` to keep Terraform code lean and auditable.
-- **Config source of truth**: The GitOps repo (`https://github.com/cloud-neutral-workshop/gitops.git`) stores `config/accounts/bootstrap.yaml`, defining canonical names, regions, and tags. Terragrunt reads it via `GITOPS_REPO_ROOT` (defaults to `../gitops` relative to this repo).
+- **Config source of truth**: The GitOps repo (`https://github.com/cloud-neutral-workshop/gitops.git`) stores `config/accounts/bootstrap.yaml`, defining canonical names, regions, and tags. Terragrunt reads it via `GITOPS_REPO_ROOT` (defaults to `../gitops` relative to this repo). Clone that repository locally or set `GITOPS_REPO_ROOT` to your desired path to keep configuration and modules separated. You can also override the config file path with `GITOPS_BOOTSTRAP_CONFIG` (for example, `config/xzerolab/sit/aws-cloud/account/bootstrap.yaml` inside the GitOps repo).
 
 ## How to Run with Terragrunt
 

--- a/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
@@ -16,9 +16,13 @@ locals {
     abspath("${get_parent_terragrunt_dir()}/../../../../../gitops")
   )
   config_root = "${local.gitops_repo_root}/config"
+  bootstrap_config_path = get_env(
+    "GITOPS_BOOTSTRAP_CONFIG",
+    "${local.config_root}/accounts/bootstrap.yaml"
+  )
 }
 
 inputs = {
-  bootstrap_config_path = "${local.config_root}/accounts/bootstrap.yaml"
+  bootstrap_config_path = local.bootstrap_config_path
   config_root           = local.gitops_repo_root
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
@@ -16,9 +16,13 @@ locals {
     abspath("${get_parent_terragrunt_dir()}/../../../../../gitops")
   )
   config_root = "${local.gitops_repo_root}/config"
+  bootstrap_config_path = get_env(
+    "GITOPS_BOOTSTRAP_CONFIG",
+    "${local.config_root}/accounts/bootstrap.yaml"
+  )
 }
 
 inputs = {
-  bootstrap_config_path = "${local.config_root}/accounts/bootstrap.yaml"
+  bootstrap_config_path = local.bootstrap_config_path
   config_root           = local.gitops_repo_root
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
@@ -12,9 +12,13 @@ locals {
     abspath("${get_parent_terragrunt_dir()}/../../../../../gitops")
   )
   config_root = "${local.gitops_repo_root}/config"
+  bootstrap_config_path = get_env(
+    "GITOPS_BOOTSTRAP_CONFIG",
+    "${local.config_root}/accounts/bootstrap.yaml"
+  )
 }
 
 inputs = {
-  bootstrap_config_path = "${local.config_root}/accounts/bootstrap.yaml"
+  bootstrap_config_path = local.bootstrap_config_path
   config_root           = local.gitops_repo_root
 }


### PR DESCRIPTION
## Summary
- add gitops_repo_name workflow_dispatch input with default https://github.com/cloud-neutral-workshop/gitops.git across AWS pipelines
- use the provided repository value when checking out the GitOps config in each workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6bd7fdfc8332b4cb4c8d79da9cd2)