### PR TITLE
Simplify bootstrap config path input

### DIFF
--- a/terraform-hcl-standard/aws-cloud/bootstrap/state/locals.tf
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/state/locals.tf
@@ -1,9 +1,5 @@
 locals {
-  config_root = coalesce(var.config_root, abspath("${path.module}/../../../../../gitops"))
-  bootstrap_config_path = coalesce(
-    var.bootstrap_config_path,
-    "${local.config_root}/config/accounts/bootstrap.yaml"
-  )
+  bootstrap_config_path = abspath(var.bootstrap_config_path)
 
   bootstrap = yamldecode(file(local.bootstrap_config_path))
 

--- a/terraform-hcl-standard/aws-cloud/bootstrap/state/variables.tf
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/state/variables.tf
@@ -13,7 +13,11 @@ variable "region" {
 variable "bootstrap_config_path" {
   description = "Path to the bootstrap account configuration YAML"
   type        = string
-  default     = null
+
+  validation {
+    condition     = var.bootstrap_config_path != null && trim(var.bootstrap_config_path) != ""
+    error_message = "Set bootstrap_config_path to the GitHub Action environment input that points to the bootstrap YAML file."
+  }
 }
 
 variable "config_root" {


### PR DESCRIPTION
## Summary
- simplify bootstrap config path resolution to rely solely on the provided GitHub Action environment input
- require an explicit bootstrap_config_path value and remove the bundled bootstrap example file

## Testing
- terraform fmt (fails: terraform not installed in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b74afa2108332843d1e9eeb22bab5)