### PR TITLE
Add TF_CONFIG fallback for bootstrap config path

### DIFF
--- a/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
@@ -11,5 +11,8 @@ terraform {
 }
 
 inputs = {
-  bootstrap_config_path = get_env("BOOTSTRAP_CONFIG_PATH", "")
+  bootstrap_config_path = coalesce(
+    get_env("TF_CONFIG", null),
+    get_env("BOOTSTRAP_CONFIG_PATH", "")
+  )
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
@@ -11,5 +11,8 @@ terraform {
 }
 
 inputs = {
-  bootstrap_config_path = get_env("BOOTSTRAP_CONFIG_PATH", "")
+  bootstrap_config_path = coalesce(
+    get_env("TF_CONFIG", null),
+    get_env("BOOTSTRAP_CONFIG_PATH", "")
+  )
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
@@ -7,5 +7,8 @@ terraform {
 }
 
 inputs = {
-  bootstrap_config_path = get_env("BOOTSTRAP_CONFIG_PATH", "")
+  bootstrap_config_path = coalesce(
+    get_env("TF_CONFIG", null),
+    get_env("BOOTSTRAP_CONFIG_PATH", "")
+  )
 }


### PR DESCRIPTION
## Summary
- allow bootstrap modules to read the bootstrap config path from TF_CONFIG if provided
- retain support for existing BOOTSTRAP_CONFIG_PATH environment variable

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b90ab319883328973aa079280c589)