### PR TITLE
Use BOOTSTRAP_CONFIG_PATH for bootstrap configuration inputs

### DIFF
--- a/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
@@ -35,6 +35,7 @@ env:
   TG_VERSION: 0.67.14
   GITOPS_REPO_ROOT: gitops
   GITOPS_BOOTSTRAP_CONFIG: ${{ github.event.inputs.gitops_bootstrap_config || 'config/xzerolab/sit/aws-cloud/account/bootstrap.yaml' }}
+  BOOTSTRAP_CONFIG_PATH: ${{ format('{0}/{1}/{2}', github.workspace, env.GITOPS_REPO_ROOT, env.GITOPS_BOOTSTRAP_CONFIG) }}
 
 jobs:
   bootstrap:

--- a/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/identity/terragrunt.hcl
@@ -12,7 +12,7 @@ terraform {
 
 inputs = {
   bootstrap_config_path = coalesce(
-    get_env("TF_CONFIG", null),
-    get_env("BOOTSTRAP_CONFIG_PATH", "")
+    trimspace(get_env("BOOTSTRAP_CONFIG_PATH", "")),
+    null
   )
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/lock/terragrunt.hcl
@@ -12,7 +12,7 @@ terraform {
 
 inputs = {
   bootstrap_config_path = coalesce(
-    get_env("TF_CONFIG", null),
-    get_env("BOOTSTRAP_CONFIG_PATH", "")
+    trimspace(get_env("BOOTSTRAP_CONFIG_PATH", "")),
+    null
   )
 }

--- a/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
+++ b/terraform-hcl-standard/aws-cloud/bootstrap/state/terragrunt.hcl
@@ -8,7 +8,7 @@ terraform {
 
 inputs = {
   bootstrap_config_path = coalesce(
-    get_env("TF_CONFIG", null),
-    get_env("BOOTSTRAP_CONFIG_PATH", "")
+    trimspace(get_env("BOOTSTRAP_CONFIG_PATH", "")),
+    null
   )
 }


### PR DESCRIPTION
## Summary
- remove TF_CONFIG and rely on BOOTSTRAP_CONFIG_PATH for the GitOps bootstrap config path in the workflow
- simplify bootstrap Terragrunt modules to read bootstrap_config_path solely from BOOTSTRAP_CONFIG_PATH

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b9330d88c8332933f2fef75156aed)