### PR TITLE
Fix bootstrap config path expression

### DIFF
--- a/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
+++ b/.github/workflows/iac-pipeline-aws-global-bootstrap.yaml
@@ -35,7 +35,7 @@ env:
   TG_VERSION: 0.67.14
   GITOPS_REPO_ROOT: gitops
   GITOPS_BOOTSTRAP_CONFIG: ${{ github.event.inputs.gitops_bootstrap_config || 'config/xzerolab/sit/aws-cloud/account/bootstrap.yaml' }}
-  BOOTSTRAP_CONFIG_PATH: ${{ env.TG_ROOT }}/${{ env.GITOPS_REPO_ROOT}}/${{ env.GITOPS_BOOTSTRAP_CONFIG) }}
+  BOOTSTRAP_CONFIG_PATH: terraform-hcl-standard/aws-cloud/bootstrap/gitops/${{ github.event.inputs.gitops_bootstrap_config || 'config/xzerolab/sit/aws-cloud/account/bootstrap.yaml' }}
 
 jobs:
   bootstrap:


### PR DESCRIPTION
## Summary
- replace invalid env reference for bootstrap config path with a direct expression using workflow inputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b98f714a48332867f865345db02de)