### PR TITLE
Rename bootstrap workflow for multi-cloud control

### DIFF
--- a/.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml
+++ b/.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml
@@ -1,4 +1,4 @@
-name: AWS Cloud Account Bootstrap
+name: Multi-Cloud Account Bootstrap
 
 concurrency:
   group: terraform-bootstrap-${{ github.ref }}
@@ -8,8 +8,8 @@ on:
   push:
   pull_request:
     paths:
-      - '.github/workflows/iac-pipeline-aws-global-bootstrap.yaml'
-      - 'terraform-hcl-standard/aws-cloud/bootstrap/**'
+      - '.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml'
+      - 'terraform-hcl-standard/**'
   workflow_dispatch:
     inputs:
       deploy_action:
@@ -28,14 +28,18 @@ on:
         description: "Path to bootstrap config file within the GitOps repo"
         type: string
         default: config/xzerolab/sit/aws-cloud/account/bootstrap.yaml
+      tg_root:
+        description: "Terragrunt root directory"
+        type: string
+        default: terraform-hcl-standard/aws-cloud/bootstrap
 
 env:
-  TG_ROOT: terraform-hcl-standard/aws-cloud/bootstrap
+  TG_ROOT: ${{ github.event.inputs.tg_root || 'terraform-hcl-standard/aws-cloud/bootstrap' }}
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}
   TG_VERSION: 0.67.14
   GITOPS_REPO_ROOT: gitops
   GITOPS_BOOTSTRAP_CONFIG: ${{ github.event.inputs.gitops_bootstrap_config || 'config/xzerolab/sit/aws-cloud/account/bootstrap.yaml' }}
-  BOOTSTRAP_CONFIG_PATH: ${{ env.TG_ROOT }}/${{ env.GITOPS_REPO_ROOT}}/${{ env.GITOPS_BOOTSTRAP_CONFIG) }}
+  BOOTSTRAP_CONFIG_PATH: ${{ format('{0}/{1}/{2}', github.event.inputs.tg_root || 'terraform-hcl-standard/aws-cloud/bootstrap', 'gitops', github.event.inputs.gitops_bootstrap_config || 'config/xzerolab/sit/aws-cloud/account/bootstrap.yaml') }}
 
 jobs:
   bootstrap:
@@ -69,7 +73,7 @@ jobs:
           - S3: create remote state bucket (versioned + SSE + public access block)
           - DynamoDB: create state lock table with encryption + PITR
 
-          Terragrunt orchestrates state → lock → identity. Resource names and regions follow terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml.
+          Terragrunt orchestrates state → lock → identity. Resource names and regions follow the bootstrap configuration in the selected TG root (${TG_ROOT}).
           SUMMARY
 
       - uses: hashicorp/setup-terraform@v3
@@ -91,7 +95,7 @@ jobs:
       - name: Force Destroy Bootstrap Resources
         if: env.DEPLOY_ACTION == 'destroy'
         env:
-          CONFIG_PATH: terraform-hcl-standard/aws-cloud/config/accounts/bootstrap.yaml
+          CONFIG_PATH: ${{ env.TG_ROOT }}/config/accounts/bootstrap.yaml
         run: |
           ./scripts/aws-bootstrap-force-destroy.sh
 


### PR DESCRIPTION
## Summary
- rename the bootstrap workflow to the multi-cloud flavor file name
- allow bootstrap config path and supporting steps to honor the tg_root input for multi-cloud use
- broaden path triggers to cover the renamed workflow and any terragrunt roots

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b98f714a48332867f865345db02de)