### PR TITLE
Use git clone for GitOps config checkout

### DIFF
--- a/.github/workflows/iac-pipeline-mutli-cloud-bootstrap..yaml
+++ b/.github/workflows/iac-pipeline-mutli-cloud-bootstrap..yaml
@@ -50,11 +50,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Checkout GitOps config
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.TG_ROOT }}/gitops
-          repository: ${{ env.GITOPS_REPO }}
-          ref: ${{ github.event.inputs.gitops_repo_ref || 'main' }}
+        run: |
+          git clone --branch "${{ github.event.inputs.gitops_repo_ref || 'main' }}" \
+            --depth 1 "${{ env.GITOPS_REPO }}" "${{ env.TG_ROOT }}/gitops"
 
       - name: Document Bootstrap Scope
         run: |


### PR DESCRIPTION
## Summary
- replace the GitOps checkout step to clone the repository directly via git clone

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba6b0ff2883328865ffba3268ff1a)