### PR TITLE
ci: fix AWS OIDC authentication failure

### DIFF
--- a/.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml
+++ b/.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml
@@ -33,6 +33,10 @@ on:
         type: string
         default: config/xzerolab/sit/aws-cloud/account/bootstrap.yaml
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   TG_VERSION: 0.67.14
   TG_ROOT: ${{ github.event.inputs.bootstrap_cloud || 'terraform-hcl-standard/aws-cloud/bootstrap' }}

--- a/.github/workflows/iac-pipeline-mutli-cloud-landingzone-baseline.yaml
+++ b/.github/workflows/iac-pipeline-mutli-cloud-landingzone-baseline.yaml
@@ -28,6 +28,10 @@ on:
         type: string
         default: main
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   TF_WORKDIR: terraform-hcl-standard/aws-cloud
   DEPLOY_ACTION: ${{ github.event.inputs.deploy_action || 'plan' }}


### PR DESCRIPTION
Adds missing `permissions: id-token: write` to bootstrap and landingzone workflows which caused `aws-actions/configure-aws-credentials` to fail with `Error: Credentials could not be loaded`.