### PR TITLE
fix: 主机名与服务域名一律由 TARGET_DOMAIN_BASE 拼接，去掉硬编码

### DIFF
--- a/terraform-hcl-standard/vultr-vps/config/resources/prod/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/prod/agent-proxy.yaml
@@ -19,4 +19,4 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - agent-proxy.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - agent-proxy.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/prod/ai-workspace.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/prod/ai-workspace.yaml
@@ -19,5 +19,5 @@ hosts:
     host_vars:
       role: primary
       service_domains: 
-        - ai-workspace.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
-        - postgresql-ai-workspace.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - ai-workspace.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-ai-workspace.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/prod/infra-platform.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/prod/infra-platform.yaml
@@ -19,5 +19,5 @@ hosts:
     host_vars:
       role: primary
       service_domains: 
-        - infra-platform.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
-        - postgresql-platform.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - infra-platform.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-platform.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/prod/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/prod/web-saas.yaml
@@ -9,7 +9,7 @@ ssh_keys:
     public: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDEsuS135lzjVvlH2iNrKz23lDFr7b686xs4d2HINP2glFPmgkgx1D6Dqwisb1UbhWHZmUUzRxXeNlE8fiaO0TXN/C0dsdUxgopnQRyakcA+gfJqqb38Syx8eqdC7mQy9ygOf763dWm6d/SYZ8WgNWLldk4QF9DiZOW9K22DMtY4/1Cqe/YE/WGpOMVr9T9BwvmOjarjWp2OPbx6RVlSOd735Mze5X+cJ9QqdLaisCiSoJ3j9S6dulcxm+7ghPfATvxlJyZWSrRrVqnmV45lPbeuUHlIEyuK1PK2MS6NtUP03ZhdRYJQKZLECpR5xAO/BliOtDdRornvHV1gutYD8/n3IS8sRVzYPvN9DuOhzBnBQUgciu2++R8zMfdVoH7mSbsE8u++vMcBk3UJ1Op0Ct+trl2bsnue96cAnoiII08JKwAaczD5uZIGhdkGV8zKnChNCjzCxP0i4PV/MYW04eWmH+E8G81zq4ZsvrvPYmilBbRrkwHvvbPba3SSb2F2As= shenlan@shenlandeMacBook-Air-2.local"
 
 hosts:
-  - name: console-nat.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+  - name: console-nat.{{ env['TARGET_DOMAIN_BASE'] }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true
@@ -20,5 +20,5 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - console.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
-        - postgresql-saas.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - console.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-saas.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/sit/all-in-one.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/sit/all-in-one.yaml
@@ -33,8 +33,8 @@ hosts:
       role: primary
       # 逗号分隔的服务域名；cloudflare_dns 角色据此为本机 IP 建 A 记录
       service_domains: 
-        - xworkmate-bridge-debian-13.{{ env.get('TARGET_DOMAIN_BASE', 'svc.plus') }}
-        - postgresql-ai-workspace.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - xworkmate-bridge-debian-13.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-ai-workspace.{{ env['TARGET_DOMAIN_BASE'] }}
 
   - name: ai-ubuntu2604
     os_name: "Ubuntu 26.04 LTS x64"
@@ -46,4 +46,4 @@ hosts:
     tags: [ubuntu]
     host_vars:
       role: secondary
-      service_domains: xworkmate-bridge-ubuntu-26.{{ env.get('TARGET_DOMAIN_BASE', 'svc.plus') }}
+      service_domains: xworkmate-bridge-ubuntu-26.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
@@ -19,4 +19,4 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - agent-proxy.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - agent-proxy.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/ai-workspace.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/ai-workspace.yaml
@@ -19,5 +19,5 @@ hosts:
     host_vars:
       role: primary
       service_domains: 
-        - ai-workspace.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
-        - postgresql-ai-workspace.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - ai-workspace.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-ai-workspace.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/infra-platform.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/infra-platform.yaml
@@ -19,5 +19,5 @@ hosts:
     host_vars:
       role: primary
       service_domains: 
-        - infra-platform.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
-        - postgresql-platform.{{ env.get('TARGET_DOMAIN_BASE', 'onwalk.net') }}
+        - infra-platform.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-platform.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
@@ -11,7 +11,7 @@ ssh_keys:
     public: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDEsuS135lzjVvlH2iNrKz23lDFr7b686xs4d2HINP2glFPmgkgx1D6Dqwisb1UbhWHZmUUzRxXeNlE8fiaO0TXN/C0dsdUxgopnQRyakcA+gfJqqb38Syx8eqdC7mQy9ygOf763dWm6d/SYZ8WgNWLldk4QF9DiZOW9K22DMtY4/1Cqe/YE/WGpOMVr9T9BwvmOjarjWp2OPbx6RVlSOd735Mze5X+cJ9QqdLaisCiSoJ3j9S6dulcxm+7ghPfATvxlJyZWSrRrVqnmV45lPbeuUHlIEyuK1PK2MS6NtUP03ZhdRYJQKZLECpR5xAO/BliOtDdRornvHV1gutYD8/n3IS8sRVzYPvN9DuOhzBnBQUgciu2++R8zMfdVoH7mSbsE8u++vMcBk3UJ1Op0Ct+trl2bsnue96cAnoiII08JKwAaczD5uZIGhdkGV8zKnChNCjzCxP0i4PV/MYW04eWmH+E8G81zq4ZsvrvPYmilBbRrkwHvvbPba3SSb2F2As= shenlan@shenlandeMacBook-Air-2.local"
 
 hosts:
-  - name: console-nat.{{ env.get('TARGET_DOMAIN_BASE', 'svc.plus') }}
+  - name: console-nat.{{ env['TARGET_DOMAIN_BASE'] }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true
@@ -22,5 +22,5 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - console-uat.{{ env.get('TARGET_DOMAIN_BASE', 'svc.plus') }}
-        - postgresql-saas-uat.{{ env.get('TARGET_DOMAIN_BASE', 'svc.plus') }}
+        - console-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-saas-uat.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/scripts/generate.py
+++ b/terraform-hcl-standard/vultr-vps/scripts/generate.py
@@ -65,9 +65,29 @@ def _jinja():
     return env
 
 
+# 资源声明里的主机名与服务域名都由 TARGET_DOMAIN_BASE 拼接。Jinja 默认的
+# Undefined 会把缺失变量渲染成空串, 于是 console-nat.{{...}} 变成 "console-nat."
+# —— 一个看起来像成功、实际错误的主机名。这里显式要求它必须存在。
+REQUIRED_TEMPLATE_ENV = ("TARGET_DOMAIN_BASE",)
+
+
+def _assert_required_env(content, path):
+    missing = [
+        k for k in REQUIRED_TEMPLATE_ENV
+        if k in content and not os.environ.get(k)
+    ]
+    if missing:
+        raise SystemExit(
+            f"{path}: required template variable(s) not set: {', '.join(missing)}. "
+            "Hostnames and service domains are composed from them; rendering "
+            "without a value would silently produce a truncated domain."
+        )
+
+
 def load_yaml(path):
     with open(path, encoding="utf-8") as fh:
         content = fh.read()
+    _assert_required_env(content, path)
     from jinja2 import Template
     rendered = Template(content).render(env=os.environ)
     return yaml.safe_load(rendered) or {}


### PR DESCRIPTION
## 问题

每个资源声明各自带着硬编码 fallback,**而这些 fallback 互相矛盾**:

| 文件 | fallback |
|---|---|
| `uat/web-saas.yaml` | `svc.plus` |
| `uat/agent-proxy.yaml`、`uat/ai-workspace.yaml`、`uat/infra-platform.yaml` | `onwalk.net` |
| `sit/all-in-one.yaml` | **两者都有** |

`sit/all-in-one.yaml` 最典型 —— **同一台主机的两个服务域名**:第 36 行 `svc.plus`,第 37 行 `onwalk.net`。

`svc.plus` 是**生产 zone**。任何走到这些默认值的 run,都会给 uat / sit 主机渲染出生产形态的名字。

## 改动

删除全部 **19 处** fallback,主机名与服务域名一律来自 `TARGET_DOMAIN_BASE`,**任何位置不再出现域名字面量**。

## 顺带修掉一个"看起来成功"的失败模式

Jinja 默认的 `Undefined` 在键缺失时渲染成**空字符串**而非抛错,所以

```jinja
console-nat.{{ env['TARGET_DOMAIN_BASE'] }}
```

会变成 `console-nat.` —— **一个看起来已渲染、实际错误的主机名**。

在 `generate.py` 里加了显式检查:资源文件引用了必需模板变量而该变量未设置时,**直接退出并指出是哪个变量**,而不是产出一个被截断的域名。

检查限定在一个具名列表内,而不是把整个 Environment 切成 `StrictUndefined` —— 后者会改变这些模板里所有其它可选变量的行为。

## 影响范围

`TARGET_DOMAIN_BASE` 在 CI 中始终由路由步骤提供,所以本改动只影响本地/手工渲染 —— **而那恰恰是静默用错默认值最不容易被发现的地方**。

## 关联

调用侧的硬编码在 [platform-ops-toolkit#63](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/63) 一并消除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)