### PR TITLE
feat(vultr): add isolated resize-instance module

### DIFF
--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/README.md
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/README.md
@@ -1,0 +1,14 @@
+# resize-instance
+
+Creates a Vultr replacement instance for a resize operation. The module is
+intentionally isolated from the primary environment state so a failed backup,
+restore, health check, or DNS cutover cannot destroy or rewrite the source
+instance.
+
+The caller must provide either `snapshot_id` or `os_id`. Backup creation,
+service restore, health checks, DNS/Reserved IP cutover, observation, and
+source-instance cleanup are orchestration concerns owned by the delivery
+workflow.
+
+The replacement resource has `prevent_destroy = true`; cleanup must be an
+explicit, separately approved operation after the observation window.

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/main.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/main.tf
@@ -1,0 +1,17 @@
+resource "vultr_instance" "replacement" {
+  label       = var.label
+  region      = var.region
+  plan        = var.target_plan
+  os_id       = var.snapshot_id == null ? var.os_id : null
+  snapshot_id = var.snapshot_id
+  enable_ipv6 = var.enable_ipv6
+  backups     = var.backups ? "enabled" : "disabled"
+  tags        = concat(var.tags, ["resize-replacement", "resize-operation-${var.operation_id}"])
+  vpc_ids     = var.vpc_id == null ? [] : [var.vpc_id]
+  ssh_key_ids = var.ssh_key_ids
+  user_data   = var.user_data
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/outputs.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "Replacement instance ID."
+  value       = vultr_instance.replacement.id
+}
+
+output "main_ip" {
+  description = "Replacement public IPv4 address."
+  value       = vultr_instance.replacement.main_ip
+}
+
+output "label" {
+  description = "Replacement instance label."
+  value       = vultr_instance.replacement.label
+}
+
+output "plan" {
+  description = "Replacement plan."
+  value       = vultr_instance.replacement.plan
+}

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/variables.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/variables.tf
@@ -1,0 +1,74 @@
+variable "label" {
+  description = "Replacement instance label."
+  type        = string
+}
+
+variable "region" {
+  description = "Vultr region code."
+  type        = string
+}
+
+variable "target_plan" {
+  description = "Vultr plan for the replacement instance."
+  type        = string
+}
+
+variable "os_id" {
+  description = "Vultr OS ID when creating from a clean image."
+  type        = number
+  default     = null
+}
+
+variable "snapshot_id" {
+  description = "Optional Vultr snapshot used to restore the replacement instance."
+  type        = string
+  default     = null
+}
+
+variable "enable_ipv6" {
+  description = "Whether IPv6 should be enabled."
+  type        = bool
+  default     = true
+}
+
+variable "backups" {
+  description = "Whether automatic backups should be enabled on the replacement."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags applied to the replacement instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "ssh_key_ids" {
+  description = "SSH key IDs attached to the replacement instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "user_data" {
+  description = "Cloud-init user data for the replacement instance."
+  type        = string
+  default     = ""
+}
+
+variable "vpc_id" {
+  description = "Optional VPC ID."
+  type        = string
+  default     = null
+}
+
+variable "operation_id" {
+  description = "Resize operation ID used for traceability."
+  type        = string
+}
+
+check "source_image" {
+  assert {
+    condition     = var.snapshot_id != null || var.os_id != null
+    error_message = "Either snapshot_id or os_id must be provided."
+  }
+}

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/versions.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = "~> 2.19"
+    }
+  }
+}


### PR DESCRIPTION
## Outcome
Add an isolated Terraform module for replacement VPS instances used by the resize workflow.

## Changes
- Creates a replacement Vultr instance from a snapshot or OS image.
- Uses operation-specific tags and isolated state expectations.
- Exposes replacement instance ID, IP, label, and plan.
- Prevents accidental destruction from the operation state.

## Verification
- `git diff --check`
- Shell/workflow integration is provided by the companion platform-ops-toolkit PR.