### PR TITLE
fix(vultr): schedule backups for resize replacements

### DIFF
--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/README.md
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/README.md
@@ -12,3 +12,7 @@ workflow.
 
 The replacement resource has `prevent_destroy = true`; cleanup must be an
 explicit, separately approved operation after the observation window.
+
+Automatic backups default to enabled. The module supplies the required Vultr
+`backups_schedule` block with a daily schedule; callers can override
+`backup_schedule_type` or set `backups = false`.

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/main.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/main.tf
@@ -11,6 +11,13 @@ resource "vultr_instance" "replacement" {
   ssh_key_ids = var.ssh_key_ids
   user_data   = var.user_data
 
+  dynamic "backups_schedule" {
+    for_each = var.backups ? [1] : []
+    content {
+      type = var.backup_schedule_type
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/variables.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/variables.tf
@@ -37,6 +37,17 @@ variable "backups" {
   default     = true
 }
 
+variable "backup_schedule_type" {
+  description = "Vultr backup schedule type when automatic backups are enabled."
+  type        = string
+  default     = "daily"
+
+  validation {
+    condition     = contains(["daily", "weekly", "monthly", "daily_alt_even", "daily_alt_odd"], var.backup_schedule_type)
+    error_message = "backup_schedule_type must be a Vultr-supported schedule type."
+  }
+}
+
 variable "tags" {
   description = "Tags applied to the replacement instance."
   type        = list(string)


### PR DESCRIPTION
## Outcome
Adds the required `backups_schedule` block whenever the resize replacement enables Vultr automatic backups. The default schedule is daily and can be overridden or disabled by callers.

## Issues
- Fixes failed resize run 29933685342: `Backups are set to enabled please provide a backups_schedule`.

## Verification
- `git diff --check`
- Reviewed against the current Vultr provider instance resource documentation.
- Local Terraform CLI is unavailable in this workspace; the guarded live workflow will validate provider apply after merge.