### PR TITLE
fix(uat): declare the accounts service domain so DNS gets published

### DIFF
--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
@@ -23,4 +23,9 @@ hosts:
       role: primary
       service_domains:
         - console-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        # accounts 是 web-saas 栈里独立的对外站点: Caddyfile 给它单独一个
+        # https:// 块(OAuth 回调固定落在这里, console 只是发起跳转的一方)。
+        # 少了这条 A 记录, Caddy 的 ACME HTTP-01 验证拿不到解析、签不出证书,
+        # 而 console 那个站点照常可用 —— 于是表现成"登录跳转过去就白屏"。
+        - accounts-uat.{{ env['TARGET_DOMAIN_BASE'] }}
         - postgresql-saas-uat.{{ env['TARGET_DOMAIN_BASE'] }}


### PR DESCRIPTION
\`accounts-uat.onwalk.net\` **完全没有 A 记录**。实测：

\`\`\`
console-uat.onwalk.net  -> 167.179.64.91
accounts-uat.onwalk.net -> (空)
\`\`\`

## 根因

DNS 记录来自 CMDB 里每台主机的 \`service_domains\`（playbooks 的 \`update_site_dns.yml\` 据此构造 \`cloudflare_dns_records\`）。UAT web-saas 主机只声明了 console 与 postgresql-saas。

但 web-saas 的 Caddyfile **给 accounts 单独开了一个 \`https://\` 站点块** —— OAuth 回调固定落在 accounts 上，console 只是发起跳转的一方。

缺这条记录 → Caddy 对该域名的 ACME HTTP-01 验证无法解析 → 签不出证书；而 console 那个站点一切正常。**表现出来是"点登录跳过去就白屏"，看起来像应用 bug，而不是一条缺失的 DNS 记录。**

## 关于 prod

\`prod/web-saas.yaml\` 有完全相同的缺口（只有 console + postgresql-saas）。**刻意没有一并改** —— 往生产加一条 DNS 记录是独立决策，不该是 UAT 修复的副作用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)