### PR TITLE
feat(uat): declare Billing Caddy DNS record

### DIFF
--- a/docs/tasks/2026-08-02-billing-caddy-cross-node-dns.md
+++ b/docs/tasks/2026-08-02-billing-caddy-cross-node-dns.md
@@ -1,0 +1,13 @@
+# Billing Caddy 跨节点 DNS 声明
+
+`web-saas` 主机上的 Caddy 为 agent-proxy 提供受源 IP 限制的 Billing job
+入口。这里仅声明 DNS 记录，真正是否渲染站点由 playbooks 根据
+`WEB_SAAS_BILLING_DOMAIN` 与 `WEB_SAAS_BILLING_ALLOWED_CIDRS` 决定。
+
+- UAT：`billing-uat.<TARGET_DOMAIN_BASE>`；
+
+本次只增加 UAT DNS 记录；生产不增加 Billing 外部入口，也不改变生产
+`BILLING_SERVICE_BASE_URL`。
+
+这样 DNS、Caddy、agent `billing.baseURL` 三者使用同一域名契约，避免出现“Caddy
+已有路由但域名没有 A 记录”的半通状态。

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
@@ -28,4 +28,7 @@ hosts:
         # 少了这条 A 记录, Caddy 的 ACME HTTP-01 验证拿不到解析、签不出证书,
         # 而 console 那个站点照常可用 —— 于是表现成"登录跳转过去就白屏"。
         - accounts-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        # Billing job trigger 只允许 agent-proxy 通过 web-saas Caddy 访问；
+        # 该域名与 agent-proxy CIDR matcher 配套生成。
+        - billing-uat.{{ env['TARGET_DOMAIN_BASE'] }}
         - postgresql-saas-uat.{{ env['TARGET_DOMAIN_BASE'] }}


### PR DESCRIPTION
## Outcome
- Add `billing-uat.<TARGET_DOMAIN_BASE>` to the UAT web-saas service DNS declarations.
- Keep production resource declarations unchanged.
- Document the DNS/Caddy/agent URL contract.

## Verification
- `git diff --check`
- YAML declaration inspected for the UAT web-saas resource.

## Related
- Complements the Playbooks and Platform Ops PRs for UAT cross-node Billing/Exporter collection.