### PR TITLE
fix: downgrade vultr provider to stable version 2.21.0 to avoid api crashes

### DIFF
--- a/terraform-hcl-standard/vultr-vps/modules/compute/versions.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/compute/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     vultr = {
       source  = "vultr/vultr"
-      version = "~> 2.19"
+      version = "= 2.21.0"
     }
   }
 }

--- a/terraform-hcl-standard/vultr-vps/modules/iam/versions.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/iam/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     vultr = {
       source  = "vultr/vultr"
-      version = "~> 2.19"
+      version = "= 2.21.0"
     }
   }
 }

--- a/terraform-hcl-standard/vultr-vps/modules/resize-instance/versions.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/resize-instance/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     vultr = {
       source  = "vultr/vultr"
-      version = "~> 2.19"
+      version = "= 2.21.0"
     }
   }
 }


### PR DESCRIPTION
Downgrades the vultr terraform provider to 2.21.0 to workaround Vultr API panics and timeouts when instances are missing or tagging fails.