### PR TITLE
fix(vultr): stop the backup-schedule race that poisons Terraform state

### DIFF
--- a/terraform-hcl-standard/vultr-vps/envs/ai-workspace/.gitignore
+++ b/terraform-hcl-standard/vultr-vps/envs/ai-workspace/.gitignore
@@ -6,6 +6,7 @@ variables.tf
 cloud-init.yaml
 terraform.auto.tfvars.json
 cmdb.json
+hosts_manifest.json
 inventory.ini
 # render_backend_tf.py 渲染的 S3 兼容 backend（含 endpoint，按环境派生，不入库）
 backend.tf

--- a/terraform-hcl-standard/vultr-vps/envs/site-migration-toolkit/.gitignore
+++ b/terraform-hcl-standard/vultr-vps/envs/site-migration-toolkit/.gitignore
@@ -6,6 +6,7 @@ variables.tf
 cloud-init.yaml
 terraform.auto.tfvars.json
 cmdb.json
+hosts_manifest.json
 inventory.ini
 # render_backend_tf.py 渲染的 S3 兼容 backend（含 endpoint，按环境派生，不入库）
 backend.tf

--- a/terraform-hcl-standard/vultr-vps/modules/compute/main.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/compute/main.tf
@@ -25,13 +25,19 @@ variable "enable_ipv6" {
 }
 
 variable "backups" {
-  description = "启用自动备份"
+  description = <<-EOT
+    是否为该实例启用自动备份。
+
+    注意: 这个开关不由 vultr_instance 直接执行, 见下方 resource 里的说明。
+    渲染层把它写进 hosts_manifest.json, 由 apply 之后的幂等对账步骤
+    (platform-ops_provision_reconcile-backup-schedules.sh) 调 Vultr API 落实。
+  EOT
   type        = bool
   default     = false
 }
 
 variable "backups_schedule" {
-  description = "自动备份计划（UTC）"
+  description = "自动备份计划（UTC）；与 var.backups 一样由 apply 后的对账步骤落实"
   type = object({
     type = string
     hour = number
@@ -68,27 +74,37 @@ variable "user_data" {
   default     = ""
 }
 
+# 备份计划刻意不在这里声明 —— 这不是偷懒, 是绕开一个会污染 state 的
+# provider 缺陷:
+#
+# vultr provider 的 Create 在实例 status=active 之后紧接着调
+# PUT /v2/instances/{id}/backup-schedule。Vultr 侧此时实例常常还没在
+# 备份子系统里注册完, 返回 {"error":"Invalid instance-id.","status":404},
+# 于是 Create 以 "error setting backup schedule" 失败 —— 但实例已经建出来
+# 了, 它的 ID 也已经 SetId() 进了 state。结果是一条半成品记录: 资源存在于
+# state, 云上却处在一个我们没有走完创建流程的状态。人一旦手工清掉那台机器
+# (或它本就被回滚), state 里就留下一个指向已删实例的孤儿 ID, 而 2.21.0 的
+# Read 只把 "invalid instance ID" 当作 gone, 对 "instance not found" 这个
+# 措辞直接抛错, 于是之后每一次 plan 都在 refresh 阶段硬失败, 整条流水线
+# 卡死在 provision, 且重跑不会自愈。
+#
+# 因此: 实例恒以 backups=disabled 创建(创建期不再有 backup-schedule 调用),
+# 备份由 apply 之后的幂等对账步骤按 hosts_manifest.json 落实。ignore_changes
+# 保证那一步把备份打开后, 下一次 plan 不会再把它改回 disabled。
 resource "vultr_instance" "this" {
   label       = var.label
   region      = var.region
   plan        = var.plan
   os_id       = var.os_id
   enable_ipv6 = var.enable_ipv6
-  backups     = var.backups ? "enabled" : "disabled"
+  backups     = "disabled"
   tags        = var.tags
   vpc_ids     = var.vpc_id == null ? [] : [var.vpc_id]
   ssh_key_ids = var.ssh_key_ids
   user_data   = var.user_data
 
-  dynamic "backups_schedule" {
-    for_each = var.backups ? [var.backups_schedule] : []
-
-    content {
-      type = backups_schedule.value.type
-      hour = backups_schedule.value.hour
-      dow  = backups_schedule.value.dow
-      dom  = backups_schedule.value.dom
-    }
+  lifecycle {
+    ignore_changes = [backups, backups_schedule]
   }
 }
 

--- a/terraform-hcl-standard/vultr-vps/scripts/generate.py
+++ b/terraform-hcl-standard/vultr-vps/scripts/generate.py
@@ -47,11 +47,92 @@ COPY_INTO_WORKDIR = ["provider.tf", "variables.tf", "cloud-init.yaml"]
 # 逐主机可选字段的缺省值（集中定义，避免散落的硬编码字面量）。
 DEFAULT_PLAN = "vc2-4c-8gb"
 DEFAULT_ANSIBLE_USER = "root"
+DEFAULT_BACKUPS_SCHEDULE = {"type": "daily", "hour": 5}
+
+# render 阶段就落盘的静态清单：apply 之前即可读，供 destroy 作用域断言与
+# 备份计划对账使用（二者都需要“这份 profile 应该有哪些实例”这一事实，而
+# cmdb.json 要等 apply 之后才存在）。
+MANIFEST_FILE = "hosts_manifest.json"
 
 
 def _tf_id(value):
     """把任意名字转成合法的 Terraform 标识符。"""
     return re.sub(r"[^0-9a-zA-Z_]", "_", str(value))
+
+
+def _host_label(host):
+    """实例 label：前缀只来自该主机自己那份声明的 global.name_prefix。
+
+    多份资源声明组合成一个 workspace 时（web-saas + agent-proxy），全局
+    tfvars 的 name_prefix 只保留最后读到的那份，用它渲染会把别的域的前缀
+    安到本主机头上。因此前缀在合并时逐主机记住（_merge_sources 注入
+    _name_prefix），此处只做拼接。
+    """
+    prefix = str(host.get("_name_prefix", "") or "").strip()
+    name = host["name"]
+    return f"{prefix}-{name}" if prefix else name
+
+
+def _host_tags(host):
+    """实例 tags：同样带上该主机自己的前缀，空前缀不产生空标签。"""
+    prefix = str(host.get("_name_prefix", "") or "").strip()
+    tags = [str(t) for t in (host.get("tags", []) or []) if str(t).strip()]
+    return ([prefix] if prefix else []) + tags
+
+
+def _merge_sources(resources):
+    """按顺序读入多份资源声明并合并。
+
+    global 仍然合并成一份（region/user_data_file 等确实是整个 workspace 的
+    属性），但 name_prefix 属于“这份声明里的主机怎么命名”，会逐主机粘在
+    host['_name_prefix'] 上，不随后续文件被覆盖。
+    """
+    merged_glob = {}
+    merged_ssh_keys = []
+    merged_hosts = []
+
+    for res_path in resources.split(","):
+        res_path = res_path.strip()
+        if not res_path:
+            continue
+        data = load_yaml(res_path)
+        source_glob = data.get("global", {}) or {}
+        merged_glob.update(source_glob)
+        for key in data.get("ssh_keys", []) or []:
+            if key not in merged_ssh_keys:
+                merged_ssh_keys.append(key)
+        for host in data.get("hosts", []) or []:
+            host = dict(host)
+            host["_name_prefix"] = source_glob.get("name_prefix", "") or ""
+            host["_source"] = res_path
+            host["label"] = _host_label(host)
+            host["tf_tags"] = _host_tags(host)
+            merged_hosts.append(host)
+
+    return merged_glob, merged_ssh_keys, merged_hosts
+
+
+def _write_manifest(workdir, hosts):
+    """写 hosts_manifest.json：apply 之前就成立的静态事实。"""
+    manifest = {
+        "hosts": [
+            {
+                "name": host["name"],
+                "label": host["label"],
+                "source": host.get("_source", ""),
+                "backups": bool(host.get("backups", False)),
+                "backups_schedule": host.get(
+                    "backups_schedule", DEFAULT_BACKUPS_SCHEDULE
+                ),
+            }
+            for host in hosts
+        ]
+    }
+    path = os.path.join(workdir, MANIFEST_FILE)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    return path
 
 
 def _jinja():
@@ -105,23 +186,7 @@ def cmd_render(args):
     workdir = args.workdir
     os.makedirs(workdir, exist_ok=True)
     
-    merged_glob = {}
-    merged_ssh_keys = []
-    merged_hosts = []
-    
-    for res_path in args.resources.split(','):
-        res_path = res_path.strip()
-        if not res_path: continue
-        data = load_yaml(res_path)
-        merged_glob.update(data.get("global", {}) or {})
-        for key in (data.get("ssh_keys", []) or []):
-            if key not in merged_ssh_keys:
-                merged_ssh_keys.append(key)
-        merged_hosts.extend(data.get("hosts", []) or [])
-
-    glob = merged_glob
-    ssh_keys = merged_ssh_keys
-    hosts = merged_hosts
+    glob, ssh_keys, hosts = _merge_sources(args.resources)
 
     rendered = (
         _jinja()
@@ -155,29 +220,20 @@ def cmd_render(args):
         json.dump(tfvars, fh, indent=2, ensure_ascii=False)
         fh.write("\n")
 
+    _write_manifest(workdir, hosts)
+
     print(f"  resources: {args.resources}")
     print(f"  workdir:   {os.path.relpath(workdir, VULTR_VPS_ROOT)}")
     print(
         f"  wrote generated_hosts.tf + {', '.join(COPY_INTO_WORKDIR)}"
-        " + terraform.auto.tfvars.json"
+        f" + terraform.auto.tfvars.json + {MANIFEST_FILE}"
     )
     print(f"  next: terraform -chdir={workdir} init && terraform -chdir={workdir} apply")
 
 
 def cmd_inventory(args):
     workdir = args.workdir
-    merged_glob = {}
-    merged_hosts = []
-    
-    for res_path in args.resources.split(','):
-        res_path = res_path.strip()
-        if not res_path: continue
-        data = load_yaml(res_path)
-        merged_glob.update(data.get("global", {}) or {})
-        merged_hosts.extend(data.get("hosts", []) or [])
-        
-    glob = merged_glob
-    hosts = merged_hosts
+    glob, _, hosts = _merge_sources(args.resources)
     default_region = glob.get("region", "nrt")
 
     try:
@@ -208,6 +264,9 @@ def cmd_inventory(args):
         cmdb[fqdn] = {
             "name": name,
             "fqdn": fqdn,
+            # 云上实例的真实 label。instance_id 会因重建而失效，label 不会，
+            # 是按名反查真实实例（resize preflight 的自愈路径）的稳定锚点。
+            "label": host["label"],
             "ip": rt.get("ip"),
             "instance_id": rt.get("instance_id"),
             "os_id": rt.get("os_id"),

--- a/terraform-hcl-standard/vultr-vps/templates/hosts.tf.j2
+++ b/terraform-hcl-standard/vultr-vps/templates/hosts.tf.j2
@@ -27,7 +27,13 @@ data "vultr_os" "{{ hid }}" {
 module "compute_{{ hid }}" {
   source = "../../modules/compute"
 
-  label       = var.name_prefix != "" ? "${var.name_prefix}-{{ host.name }}" : "{{ host.name }}"
+  # label/tags 的前缀取自该主机所属那份资源声明的 global.name_prefix, 由
+  # generate.py 逐主机解析后写死在这里 —— 不能读 var.name_prefix。多份声明
+  # 组合部署时(例如 web-saas + agent-proxy), tfvars 里的 name_prefix 只剩最
+  # 后一份文件的值, 用它会给别的域的主机安上不属于自己的前缀, 使同一台主机
+  # 的 label 随 profile 组合漂移。label 是 resize 自愈按名反查真实实例的锚点,
+  # 必须只由主机自己的声明决定。
+  label       = "{{ host.label }}"
   region      = {% if host.region %}"{{ host.region }}"{% else %}var.region{% endif %}
 
   plan        = "{{ host.plan | default('vc2-4c-8gb') }}"
@@ -35,7 +41,7 @@ module "compute_{{ hid }}" {
 
   enable_ipv6 = {{ 'true' if host.get('enable_ipv6', true) else 'false' }}
   backups     = {{ 'true' if host.get('backups', false) else 'false' }}
-  tags        = [for t in concat([var.name_prefix], {{ host.get('tags', []) | tojson }}) : t if t != ""]
+  tags        = {{ host.tf_tags | tojson }}
   ssh_key_ids = [{% for k in ssh_keys %}vultr_ssh_key.{{ k.name | tf_id }}.id{{ ", " if not loop.last }}{% endfor %}]
   user_data   = file(var.user_data_file)
 }


### PR DESCRIPTION
## 起因

[run 31085433584](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31085433584) 卡在 provision，plan 的 refresh 阶段两次报 `{"error":"instance not found","status":404}`，重跑仍然挂。往前追是一条完整的链：

| 时间 (UTC) | run | 发生了什么 |
|---|---|---|
| 08:00 | [31082261506](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31082261506) | 两台实例建出来了，然后 `error setting backup schedule: {"error":"Invalid instance-id.","status":404}` —— apply 失败，但 ID 已经写进 state |
| 14:40 | [31085433584](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31085433584) | 那两台机器在 Vultr 上已不存在，refresh 撞 404 硬失败 |

## 根因

provider 的 `resourceVultrInstanceCreate` 在实例 `status=active` 之后紧接着调 `POST /instances/{id}/backup-schedule`。Vultr 侧此时常常还没在备份子系统里注册完，返回 404 `Invalid instance-id`，于是 Create 以 diag error 结束 —— 但 `d.SetId(instance.ID)` 早已执行，实例和它的 ID 都留下了。这条半成品记录一旦对应的机器被清掉，state 里就是个孤儿 ID。

而 2.21.0 的 `resourceVultrInstanceRead` 只把 `invalid instance ID` 当作资源已消失：

```go
if strings.Contains(err.Error(), "invalid instance ID") {
    d.SetId("")   // gone
    return nil
}
return diag.Errorf("error getting instance (%s): %v", d.Id(), err)
```

Vultr 现在返回的措辞是 `instance not found`，走不进这个分支 —— 所以**降级 provider 到 2.21.0 并不能解决孤儿 state**，plan 依然每次都崩在 refresh，且重跑不会自愈。

## 改动

**1. 实例恒以 `backups = "disabled"` 创建**，创建期不再有 backup-schedule 调用，竞态消失。备份改由 apply 之后的幂等对账步骤按 `hosts_manifest.json` 落实（见 platform-ops-toolkit 的配套 PR）。`ignore_changes = [backups, backups_schedule]` 保证那一步把备份打开后，下一次 plan 不会再改回 disabled。

**2. label/tags 的前缀改为逐主机取自该主机所属声明的 `global.name_prefix`。** 多份声明组合进一个 workspace 时（`web-saas + agent-proxy`），合并后的 tfvars 只保留最后一份文件的 `name_prefix`，于是 web-saas 的主机被渲染成 `agent-proxy-uat-console-nat.onwalk.net` —— 同一台主机的 label 随 profile 组合漂移，而 label 正是 resize preflight 按名反查真实实例的锚点。

**3. render 阶段新增 `hosts_manifest.json`**：apply 之前就成立的静态清单（label / backups / backups_schedule），供 destroy 作用域断言与备份对账使用 —— 二者都需要"这份 profile 应该有哪些实例"，而 cmdb.json 要等 apply 之后才存在。cmdb.json 同时补上 label 字段。

## 兼容性

各 profile 渲染后的 label 实测：

| profile | label |
|---|---|
| uat/web-saas | `console-nat.onwalk.net` |
| prod/web-saas | `console-nat.onwalk.net` |
| sit/all-in-one | `ai-workspace-ai-debian13`, `ai-workspace-ai-ubuntu2604` |
| uat/agent-proxy | `agent-proxy-uat-agent-proxy-node-uat` |
| uat/infra-platform | `infra-platform-uat-infra-platform-node-uat` |

单文件 profile 与改动前逐字节一致，现有 state 不受影响。只有 `web-saas + agent-proxy` 组合下 web-saas 主机的 label 会从错误值改成正确值；`label` 与 `tags` 在 provider schema 里都不是 ForceNew，是 in-place update，不重建实例。

## 合并顺序

先合这个 PR，再合 platform-ops-toolkit 的配套 PR —— 后者的备份对账步骤依赖这里产出的 `hosts_manifest.json`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)