### PR TITLE
docs(readme): 按实际 IaC 模块与分类重写双语 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,195 @@
 [🇺🇸 English](README.md) | [🇨🇳 中文](README.zh.md)
 
-# AI Workspace Infrastructure Modules (iac_modules)
+# AI Workspace Infrastructure Modules (`iac_modules`)
 
-`iac_modules` is the core Infrastructure-as-Code (IaC) repository for the AI Workspace ecosystem. It provides cloud-neutral, multi-cloud GitOps orchestrations, standard Terraform/Terragrunt modules, and automated deployment pipelines for establishing a resilient, scalable AI infrastructure platform.
+`iac_modules` is the Infrastructure-as-Code repository of the AI Workspace platform. It declares
+cloud resources as YAML, renders explicit Terraform HCL from that YAML with Python + Jinja2, applies
+it per environment, and emits a CMDB (`cmdb.json`) that the Ansible layer consumes. Terraform here
+owns compute / network / storage / identity only — software configuration belongs to the playbooks
+repo on the other side of the CMDB contract.
 
-## About
+## Core paradigm
 
-- **Cloud-Neutral by Design**: Consistent resource abstraction across AWS, GCP, Azure, Alibaba Cloud, and Vultr.
-- **GitOps Orchestration**: Automated multi-environment pipelines for bootstrap, landing zone, and account matrices.
-- **VPN Overlay & Networking**: Includes configurations for establishing secure `vpn-overlay` (WireGuard, Xray) connections.
-- **Standardized HCL**: A robust library of pre-configured `terraform-hcl-standard` modules for compute, networking, and security.
+```
+config/resources/<env>/<group>.yaml          declaration — the only hand-edited entry point
+        │   scripts/generate.py render       loops run in Python + Jinja2, never inside HCL
+        ▼
+generated_hosts.tf                           one explicit module/resource block per host
+terraform.auto.tfvars.json ──▶ variables.tf  the YAML `global` section
+        │   terraform apply
+        ▼
+output "cmdb_runtime"                        runtime-only facts (ip / instance_id / resolved os_id)
+        │   scripts/generate.py inventory    merges static YAML fields + runtime outputs
+        ▼
+cmdb.json + inventory.ini                    the IaC ↔ Ansible contract
+```
 
-## Start TLDR
+Binding rules that follow from it — full text in
+[`terraform-hcl-standard/AGENTS.md`](terraform-hcl-standard/AGENTS.md) and
+[`skills/`](skills):
 
-> **Note:** These modules are designed to be consumed by CI/CD pipelines (e.g., GitHub Actions) and orchestration tools rather than being run entirely manually.
+- **No control structures in HCL.** No `for_each` / `count` / `dynamic`, no `templatefile()` with
+  `%{ for }` / `%{ if }`. Multiplicity is expanded at render time into uniquely named blocks.
+- **No topology in HCL.** Regions, plans, instance counts, domains and host vars live in YAML.
+- **No embedded scripts in HCL.** No `local-exec` provisioners, no `null_resource` shell/python.
+- **One state namespace per environment.** `sit` / `uat` / `prod` never share a backend key.
+- **Secrets never travel through files.** API keys arrive as `TF_VAR_*` env vars; generated
+  credentials are pushed to Vault for Ansible to read back — never written to YAML, tfvars or
+  handed forward on disk.
+- **Rendered artifacts are not committed.** `generated_hosts.tf`, `terraform.auto.tfvars.json`,
+  `cmdb.json`, `inventory.ini` are gitignored; a run directory tracks only `README.md` + `.gitignore`.
+
+## Layers inside a provider tree
+
+Every provider under `terraform-hcl-standard/` follows the same three-layer split — declaration,
+reusable templates, composition logic — leaving run directories as pure Terraform workdirs.
+
+| Layer | Path | Role | Tracked |
+|-------|------|------|---------|
+| Declaration | `<provider>/config/resources/<env>/*.yaml` | Resource topology per environment and per resource group | ✅ |
+| Declaration | `<provider>/config/accounts/` | Placeholder for account / bootstrap facts (state bucket, lock table, roles) — the actual YAML is sourced from the external GitOps repo via `BOOTSTRAP_CONFIG_PATH` / `TF_VAR_config_root` | `.gitkeep` only |
+| Templates | `<provider>/templates/` | Shared `provider.tf`, `variables.tf`, `backend.tf`, `cloud-init.yaml` and their `.j2` renderers | ✅ |
+| Composition | `<provider>/scripts/generate.py`, `provision.sh` | `render` + `inventory` subcommands, one-shot provisioning | ✅ |
+| Modules | `<provider>/modules/<resource>/` | Reusable resource modules consumed by the rendered blocks | ✅ |
+| Root modules | `<provider>/component/` (AWS), `<provider>/instance/` (GCP) | Per-resource Terraform roots with a `Makefile` each | ✅ |
+| Run directories | `<provider>/envs/<name>/` | Terraform workdir — receives the rendered artifacts and holds the state | README + `.gitignore` only |
+| Bootstrap | `<provider>/bootstrap/{state,lock,identity}` | Remote state bucket, lock table, deploy role/user — applied before anything else | ✅ |
+
+## Providers and their maturity
+
+| Provider | Path | Status | Modules | What exists today |
+|----------|------|--------|---------|-------------------|
+| AWS | `terraform-hcl-standard/aws-cloud/` | Production | 14 | Terragrunt bootstrap (`state` / `lock` / `identity`), `component/` roots, `sit` + `uat` + `prod` resource declarations, render + inventory scripts |
+| Vultr | `terraform-hcl-standard/vultr-vps/` | Production — reference implementation of the render pattern | 7 | Four run directories (`ai-workspace`, `dev`, `platform-ops-toolkit`, `site-migration-toolkit`), `sit` + `uat` + `prod` declarations, `provision.sh` |
+| Alibaba Cloud | `terraform-hcl-standard/ali-cloud/` | Partial | 9 | Modules + bootstrap + `envs/dev`; `config/resources` is still empty |
+| GCP | `terraform-hcl-standard/gcp-cloud/` | Skeleton | 14 | One `main.tf` per module plus `instance/` roots; no resource declarations |
+| Azure | `terraform-hcl-standard/azure-cloud/` | Skeleton | 14 | One `main.tf` per module; no run directories, no resource declarations |
+
+`utils/` at the `terraform-hcl-standard/` root holds the shared Python renderer
+(`renderer.py`, `config_loader.py`, `render_provider_backend.py`).
+
+## Module catalog by domain
+
+| Domain | AWS | Alibaba Cloud | Vultr | GCP / Azure (skeleton) |
+|--------|-----|---------------|-------|------------------------|
+| Identity & governance | `iam`, `landingzone` | `ram` | `iam` | `iam`, `landingzone` |
+| Compute | `ec2`, `keypair`, `ami_lookup` | `ecs` | `compute`, `resize-instance` | `ec2`, `keypair`, `ami_lookup` |
+| Network | `vpc`, `sg`, `alb`, `nlb` | `vpc`, `alb`, `nlb` | `vpc` | `vpc`, `sg`, `alb`, `nlb` |
+| Data & storage | `rds`, `redis`, `msk`, `s3` | `rds`, `redis`, `oss` | `data_store`, `storage` | `rds`, `redis`, `msk`, `s3` |
+| Teardown | `bootstrap-destroy` | `bootstrap-destroy` | `bootstrap-destroy` | `bootstrap-destroy` |
+
+> The GCP and Azure trees declare genuine `google_*` / `azurerm_*` resources but inherited the AWS
+> directory names (`ec2`, `s3`, `msk`, `ami_lookup`). Naming is not normalized yet.
+
+## Environments and resource groups
+
+Three environments, each with its own YAML directory, its own run directory and its own state:
+**`sit`** (integration), **`uat`** (pre-production), **`prod`**.
+
+Resource groups are the unit of declaration inside an environment — one YAML per group, one
+Terraform run per group:
+
+| Group | Ansible group / tags | Carries |
+|-------|----------------------|---------|
+| `web-saas` | `web_saas`, `database` | Console / accounts / PostgreSQL SaaS hosts, including the public service domains Caddy terminates TLS for |
+| `ai-workspace` | `ai_workspace`, `database` | The AI workspace application nodes |
+| `infra-platform` | `infra_platform`, `database` | Shared platform services |
+| `agent-proxy` | `agent_proxy` | Agent egress / proxy nodes |
+| `action-runner` | `action_runner` | Self-hosted CI runners |
+| `all-in-one` (`sit` only) | mixed | The whole stack collapsed onto a single SIT host |
+
+`uat` and `prod` are deliberately separate declarations and separate states — the CMDB produced by a
+run is the deploy source of truth for that environment, and a run must never be pointed at another
+environment's host variables.
+
+## Components outside Terraform
+
+| Path | Contents |
+|------|----------|
+| `vpn-overlay/` | Cross-site L2/L3 overlay: `wireguard/`, `xray/`, `vxlan/`, `gretap/`, `config/sites.yaml`, topology diagrams |
+| `skills/` | Binding specs — `IAC-Spec` (IaC red lines), `terraform-yaml-render-pattern` (the render pattern), `release-branch-policy` |
+| `scripts/` | Repo-level helpers — `dynamic_inventory.py`, WireGuard key generation, gitleaks auto-fix, and `workflows/` helpers for Flux, Ansible, kubeconfig and xconfig |
+| `.github/actions/` | Pipeline definitions — per-cloud landing-zone baselines, infrastructure resources, monitoring exporter/server, SSL certificate renewal |
+| `.github/workflows/` | `validate-release-pr.yml` — the only workflow that runs in this repository |
+| `example/` | Reference samples: Pulumi (Python) and plain Terraform for AWS / Azure / GCP |
+| `docs/` | Bilingual documentation set — start at [`docs/README.md`](docs/README.md) |
+
+## Quickstart
+
+> These modules are built to be driven by pipelines and by `generate.py`; running `terraform` by hand
+> inside a provider directory will not work, because run directories only exist after a render.
 
 ### Prerequisites
 
-Ensure you have the following installed if you plan to run modules locally:
 - Terraform >= 1.5.0
-- Terragrunt >= 0.50.0
-- Cloud Provider CLIs (AWS CLI, gcloud, etc.)
+- Terragrunt >= 0.67.14 (AWS bootstrap only)
+- Python 3 with `PyYAML` and `Jinja2` (`requirements.txt` installs these plus the Pulumi example deps)
+- Provider credentials — AWS via the standard credential chain / OIDC, Vultr via `TF_VAR_vultr_api_key`
 
-### Usage
+### 1. Bootstrap an account (once)
 
-1. Multi-cloud Pipelines:
-Refer to the `.github/workflows` directory for automated matrices:
+Account facts (bucket, lock table, role names) come from the external GitOps repo, not from this one:
+
 ```bash
-.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml
-.github/workflows/iac-pipeline-mutli-cloud-landingzone-baseline.yaml
+git clone https://github.com/cloud-neutral-workshop/gitops.git ../gitops
+cd terraform-hcl-standard/aws-cloud/bootstrap
+BOOTSTRAP_CONFIG_PATH=../../../../gitops/config/accounts/bootstrap.yaml make bootstrap-init bootstrap-apply
 ```
 
-2. Standard Terraform Modules:
-Navigate to the module directory and initialize:
+Creates the S3 state bucket (versioned + encrypted), the DynamoDB lock table and the deploy
+role/user. See [`aws-cloud/README.md`](terraform-hcl-standard/aws-cloud/README.md) for credential
+modes and teardown.
+
+### 2. Render, apply and produce the CMDB
+
 ```bash
-cd terraform-hcl-standard/
-terraform init
-terraform plan
+export TF_VAR_vultr_api_key=...
+cd terraform-hcl-standard/vultr-vps/scripts
+
+RESOURCES=../config/resources/uat/web-saas.yaml \
+WORKDIR=../envs/ai-workspace \
+./provision.sh
 ```
 
-3. Setup VPN Overlay:
+`provision.sh` runs the four steps in order — `generate.py render` → `terraform init && apply` →
+`generate.py inventory` → optional Ansible. To drive the steps individually:
+
 ```bash
-cd vpn-overlay/
-# Follow specific instructions for wireguard or xray setup
+python3 generate.py render    --resources ../config/resources/uat/web-saas.yaml --workdir ../envs/ai-workspace
+terraform -chdir=../envs/ai-workspace init && terraform -chdir=../envs/ai-workspace apply
+python3 generate.py inventory --resources ../config/resources/uat/web-saas.yaml --workdir ../envs/ai-workspace
 ```
 
-## Repository Structure
+### 3. Hand over to Ansible
 
-- `terraform-hcl-standard/`: Core, reusable Terraform modules.
-- `vpn-overlay/`: Secure networking and overlay configurations.
-- `.github/workflows/`: GitOps pipelines and CI/CD matrices.
-- `scripts/`: Helper scripts for environment setup and deployment.
-- `example/`: Example implementations and reference architectures.
+The playbooks repo consumes `cmdb.json` through its dynamic inventory
+(`playbooks/inventory/terraform_cmdb.py`) — it never reads tfstate. Re-run `generate.py inventory`
+after every infrastructure change.
+
+```bash
+ansible web_saas -i ../../../../playbooks/inventory/terraform_cmdb.py -m ping
+```
+
+## Before you change anything
+
+- [`terraform-hcl-standard/AGENTS.md`](terraform-hcl-standard/AGENTS.md) — binding Terraform constraints
+- [`skills/IAC-Spec/SKILL.md`](skills/IAC-Spec/SKILL.md) — IaC red lines and the IaC ↔ config-as-code boundary
+- [`skills/terraform-yaml-render-pattern/SKILL.md`](skills/terraform-yaml-render-pattern/SKILL.md) — the render pattern with its pre-commit checklist
+- [`skills/release-branch-policy/SKILL.md`](skills/release-branch-policy/SKILL.md) — branch and release policy
+
+Pre-commit self-check: `terraform fmt` clean, `terraform validate` passing, `generate.py render`
+producing valid HCL, `ansible-inventory --graph` parsing the generated inventory, no rendered
+artifacts or secrets staged.
+
+## Known gaps
+
+- GCP and Azure are single-file skeletons with AWS-inherited module names — not deployable as-is.
+- `ali-cloud/config/resources/` is empty; only `envs/dev` exists.
+- The default `--resources` paths in `generate.py` still point at the pre-split
+  `config/resources/ai-workspace-hosts.yaml`; always pass `--resources` / `RESOURCES` explicitly.
+- Documentation consolidation is tracked in [`docs/DOC_COVERAGE.md`](docs/DOC_COVERAGE.md).
 
 ## Docs / Links
 
-- [Official Website](https://www.svc.plus/)
-- [CloudNativeSuite Documentation](https://github.com/ai-workspace-infra)
+- [Official website](https://www.svc.plus/)
+- [ai-workspace-infra organization](https://github.com/ai-workspace-infra)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,59 +1,187 @@
 [🇺🇸 English](README.md) | [🇨🇳 中文](README.zh.md)
 
-# AI Workspace Infrastructure Modules (iac_modules)
+# AI Workspace 基础设施模块仓库 (`iac_modules`)
 
-`iac_modules` 是 AI Workspace 生态系统的核心基础设施即代码 (IaC) 仓库。它提供云中立的多云 GitOps 编排、标准的 Terraform/Terragrunt 模块，以及自动化的部署流水线，旨在构建弹性、可扩展的 AI 基础设施平台。
+`iac_modules` 是 AI Workspace 平台的基础设施即代码（IaC）仓库。资源以 YAML 声明，由 Python + Jinja2
+渲染成显式的 Terraform HCL，按环境 apply，并产出供 Ansible 消费的 CMDB（`cmdb.json`）。
+本仓库中的 Terraform 只负责计算 / 网络 / 存储 / 身份等云资源，软件层配置属于 CMDB 契约另一侧的
+playbooks 仓库。
 
-## 关于 (About)
+## 核心范式
 
-- **云中立设计 (Cloud-Neutral)**：跨 AWS、GCP、Azure、阿里云和 Vultr 等环境提供一致的资源抽象。
-- **GitOps 编排**：自动化的多环境流水线，支持引导层 (Bootstrap)、登陆区 (Landing Zone) 和多云账户矩阵。
-- **VPN Overlay 与网络**：包含建立安全 `vpn-overlay`（WireGuard、Xray）连接的配置。
-- **标准化 HCL 代码**：为计算、网络和安全提供强大且预配置的 `terraform-hcl-standard` 模块库。
+```
+config/resources/<env>/<group>.yaml          声明层 —— 唯一的人工维护入口
+        │   scripts/generate.py render       循环在 Python + Jinja2 侧完成，绝不进 HCL
+        ▼
+generated_hosts.tf                           每台主机一个命名唯一的显式 module/resource 块
+terraform.auto.tfvars.json ──▶ variables.tf  YAML 的 global 段
+        │   terraform apply
+        ▼
+output "cmdb_runtime"                        仅运行时才确定的事实（ip / instance_id / 解析后的 os_id）
+        │   scripts/generate.py inventory    合并 YAML 静态字段 + Terraform 运行时输出
+        ▼
+cmdb.json + inventory.ini                    IaC ↔ Ansible 契约
+```
 
-## 快速开始 (Start TLDR)
+由此派生的强制约束，完整条款见
+[`terraform-hcl-standard/AGENTS.md`](terraform-hcl-standard/AGENTS.md) 与 [`skills/`](skills)：
 
-> **注意：** 这些模块主要设计供 CI/CD 流水线（例如 GitHub Actions）和编排工具调用，而不是完全通过手动运行。
+- **HCL 内禁用控制结构**：不得使用 `for_each` / `count` / `dynamic`，不得用 `templatefile()` 配合
+  `%{ for }` / `%{ if }` 渲染；「多份资源」在渲染阶段展开为多个命名唯一的显式块。
+- **拓扑不进 HCL**：区域、机型、实例数量、域名与 host_vars 一律写在 YAML 里。
+- **HCL 内禁止内嵌脚本**：不得使用 `local-exec` provisioner，不得用 `null_resource` 跑 shell/python。
+- **状态按环境隔离**：`sit` / `uat` / `prod` 绝不复用同一个 backend key。
+- **机密不落文件**：API Key 通过 `TF_VAR_*` 环境变量注入；IaC 生成的凭证直接推送 Vault 供 Ansible
+  读取，绝不写入 YAML / tfvars，也不以文件形式向后传递。
+- **渲染产物不入库**：`generated_hosts.tf`、`terraform.auto.tfvars.json`、`cmdb.json`、
+  `inventory.ini` 均被 gitignore；运行目录只跟踪 `README.md` 与 `.gitignore`。
 
-### 前置依赖 (Prerequisites)
+## 单个 Provider 内的分层
 
-如果计划在本地运行模块，请确保安装了以下工具：
+`terraform-hcl-standard/` 下每个 provider 都遵循同一套三层切分 —— 声明 / 可复用模板 / 组合逻辑，
+env 目录退化为纯粹的 Terraform 运行目录。
+
+| 分层 | 路径 | 职责 | 是否入库 |
+|------|------|------|----------|
+| 声明 | `<provider>/config/resources/<env>/*.yaml` | 按环境、按资源分类描述拓扑 | ✅ |
+| 声明 | `<provider>/config/accounts/` | 账号 / bootstrap 事实（state 桶、锁表、角色）的占位目录；实际 YAML 由外部 GitOps 仓库经 `BOOTSTRAP_CONFIG_PATH` / `TF_VAR_config_root` 提供 | 仅 `.gitkeep` |
+| 模板 | `<provider>/templates/` | 共享的 `provider.tf`、`variables.tf`、`backend.tf`、`cloud-init.yaml` 及对应 `.j2` | ✅ |
+| 组合 | `<provider>/scripts/generate.py`、`provision.sh` | `render` + `inventory` 子命令与一键编排 | ✅ |
+| 模块 | `<provider>/modules/<resource>/` | 被渲染块复用的资源模块 | ✅ |
+| 根模块 | `<provider>/component/`（AWS）、`<provider>/instance/`（GCP） | 逐资源的 Terraform 根模块，各带一个 `Makefile` | ✅ |
+| 运行目录 | `<provider>/envs/<name>/` | Terraform workdir，承接渲染产物与 tfstate | 仅 README + `.gitignore` |
+| Bootstrap | `<provider>/bootstrap/{state,lock,identity}` | 远端状态桶、锁表、部署角色/用户，先于一切执行 | ✅ |
+
+## Provider 与成熟度分类
+
+| Provider | 路径 | 状态 | 模块数 | 现状 |
+|----------|------|------|--------|------|
+| AWS | `terraform-hcl-standard/aws-cloud/` | 生产可用 | 14 | Terragrunt bootstrap（`state` / `lock` / `identity`）、`component/` 根模块、`sit` + `uat` + `prod` 资源声明、render + inventory 脚本 |
+| Vultr | `terraform-hcl-standard/vultr-vps/` | 生产可用 —— 渲染范式的基准实现 | 7 | 四个运行目录（`ai-workspace`、`dev`、`platform-ops-toolkit`、`site-migration-toolkit`）、`sit` + `uat` + `prod` 声明、`provision.sh` |
+| 阿里云 | `terraform-hcl-standard/ali-cloud/` | 部分完成 | 9 | 模块 + bootstrap + `envs/dev`；`config/resources` 仍为空 |
+| GCP | `terraform-hcl-standard/gcp-cloud/` | 骨架 | 14 | 每个模块仅一个 `main.tf`，另有 `instance/` 根模块；无资源声明 |
+| Azure | `terraform-hcl-standard/azure-cloud/` | 骨架 | 14 | 每个模块仅一个 `main.tf`；无运行目录、无资源声明 |
+
+`terraform-hcl-standard/utils/` 存放共享的 Python 渲染器（`renderer.py`、`config_loader.py`、
+`render_provider_backend.py`）。
+
+## 模块目录（按能力域分类）
+
+| 能力域 | AWS | 阿里云 | Vultr | GCP / Azure（骨架） |
+|--------|-----|--------|-------|---------------------|
+| 身份与治理 | `iam`、`landingzone` | `ram` | `iam` | `iam`、`landingzone` |
+| 计算 | `ec2`、`keypair`、`ami_lookup` | `ecs` | `compute`、`resize-instance` | `ec2`、`keypair`、`ami_lookup` |
+| 网络 | `vpc`、`sg`、`alb`、`nlb` | `vpc`、`alb`、`nlb` | `vpc` | `vpc`、`sg`、`alb`、`nlb` |
+| 数据与存储 | `rds`、`redis`、`msk`、`s3` | `rds`、`redis`、`oss` | `data_store`、`storage` | `rds`、`redis`、`msk`、`s3` |
+| 拆除 | `bootstrap-destroy` | `bootstrap-destroy` | `bootstrap-destroy` | `bootstrap-destroy` |
+
+> GCP 与 Azure 目录里声明的确实是 `google_*` / `azurerm_*` 资源，但目录名沿用了 AWS 的叫法
+> （`ec2`、`s3`、`msk`、`ami_lookup`），命名尚未归一化。
+
+## 环境与资源分类
+
+三套环境，各自拥有独立的 YAML 目录、独立的运行目录与独立的状态：
+**`sit`**（集成）、**`uat`**（预生产）、**`prod`**（生产）。
+
+资源分类（resource group）是环境内的声明单位 —— 一个分类一份 YAML，一个分类一次 Terraform 运行：
+
+| 分类 | Ansible group / tags | 承载内容 |
+|------|----------------------|----------|
+| `web-saas` | `web_saas`、`database` | Console / accounts / PostgreSQL SaaS 主机，含 Caddy 需要签发证书的对外服务域名 |
+| `ai-workspace` | `ai_workspace`、`database` | AI workspace 应用节点 |
+| `infra-platform` | `infra_platform`、`database` | 平台侧共享服务 |
+| `agent-proxy` | `agent_proxy` | Agent 出口 / 代理节点 |
+| `action-runner` | `action_runner` | 自托管 CI Runner |
+| `all-in-one`（仅 `sit`） | 混合 | 整套栈收敛到单台 SIT 主机 |
+
+`uat` 与 `prod` 刻意是独立的声明与独立的状态：某次 apply 产出的 CMDB 就是该环境的部署事实来源，
+任何一次运行都不得指向另一个环境的主机变量。
+
+## Terraform 之外的组成部分
+
+| 路径 | 内容 |
+|------|------|
+| `vpn-overlay/` | 跨站点 L2/L3 覆盖网络：`wireguard/`、`xray/`、`vxlan/`、`gretap/`、`config/sites.yaml` 与拓扑图 |
+| `skills/` | 约束性规范 —— `IAC-Spec`（IaC 红线）、`terraform-yaml-render-pattern`（渲染范式）、`release-branch-policy` |
+| `scripts/` | 仓库级辅助脚本 —— `dynamic_inventory.py`、WireGuard 密钥生成、gitleaks 自动修复，以及 `workflows/` 下的 Flux / Ansible / kubeconfig / xconfig helper |
+| `.github/actions/` | 流水线定义 —— 各云的 Landing Zone 基线、基础设施资源、监控 exporter/server、SSL 证书续期 |
+| `.github/workflows/` | `validate-release-pr.yml` —— 本仓库唯一实际运行的 workflow |
+| `example/` | 参考样例：Pulumi（Python）与 AWS / Azure / GCP 的原生 Terraform |
+| `docs/` | 双语文档集，入口见 [`docs/README.md`](docs/README.md) |
+
+## 快速开始
+
+> 这些模块面向流水线与 `generate.py` 驱动；直接进入某个 provider 目录手跑 `terraform` 是无效的 ——
+> 运行目录要在 render 之后才成为可用的根模块。
+
+### 前置依赖
+
 - Terraform >= 1.5.0
-- Terragrunt >= 0.50.0
-- 云服务商 CLI 工具 (AWS CLI, gcloud 等)
+- Terragrunt >= 0.67.14（仅 AWS bootstrap 需要）
+- Python 3，安装 `PyYAML` 与 `Jinja2`（`requirements.txt` 除此之外还包含 Pulumi 示例的依赖）
+- Provider 凭证 —— AWS 走标准凭证链 / OIDC，Vultr 走 `TF_VAR_vultr_api_key`
 
-### 使用 (Usage)
+### 1. 账号 Bootstrap（一次性）
 
-1. 多云流水线 (Multi-cloud Pipelines)：
-请参考 `.github/workflows` 目录中自动化的矩阵配置：
+账号事实（桶名、锁表、角色名）来自外部 GitOps 仓库，而非本仓库：
+
 ```bash
-.github/workflows/iac-pipeline-mutli-cloud-bootstrap.yaml
-.github/workflows/iac-pipeline-mutli-cloud-landingzone-baseline.yaml
+git clone https://github.com/cloud-neutral-workshop/gitops.git ../gitops
+cd terraform-hcl-standard/aws-cloud/bootstrap
+BOOTSTRAP_CONFIG_PATH=../../../../gitops/config/accounts/bootstrap.yaml make bootstrap-init bootstrap-apply
 ```
 
-2. 标准 Terraform 模块：
-进入模块目录并初始化：
+创建 S3 状态桶（开启版本控制与加密）、DynamoDB 锁表与部署角色/用户。凭证模式与拆除流程见
+[`aws-cloud/README.md`](terraform-hcl-standard/aws-cloud/README.md)。
+
+### 2. 渲染、apply 并产出 CMDB
+
 ```bash
-cd terraform-hcl-standard/
-terraform init
-terraform plan
+export TF_VAR_vultr_api_key=...
+cd terraform-hcl-standard/vultr-vps/scripts
+
+RESOURCES=../config/resources/uat/web-saas.yaml \
+WORKDIR=../envs/ai-workspace \
+./provision.sh
 ```
 
-3. 配置 VPN Overlay：
+`provision.sh` 按序执行四步 —— `generate.py render` → `terraform init && apply` →
+`generate.py inventory` →（可选）Ansible。也可以逐步执行：
+
 ```bash
-cd vpn-overlay/
-# 根据具体说明进行 wireguard 或 xray 配置
+python3 generate.py render    --resources ../config/resources/uat/web-saas.yaml --workdir ../envs/ai-workspace
+terraform -chdir=../envs/ai-workspace init && terraform -chdir=../envs/ai-workspace apply
+python3 generate.py inventory --resources ../config/resources/uat/web-saas.yaml --workdir ../envs/ai-workspace
 ```
 
-## 仓库结构 (Repository Structure)
+### 3. 交接给 Ansible
 
-- `terraform-hcl-standard/`: 核心且可重用的 Terraform 模块。
-- `vpn-overlay/`: 安全网络与覆盖网络配置。
-- `.github/workflows/`: GitOps 流水线和 CI/CD 矩阵。
-- `scripts/`: 环境搭建与部署的辅助脚本。
-- `example/`: 示例实现与参考架构。
+playbooks 仓库通过动态 inventory（`playbooks/inventory/terraform_cmdb.py`）消费 `cmdb.json`，
+不直接读取 tfstate。每次基础设施变更后都要重跑 `generate.py inventory`。
 
-## 文档 / 链接 (Docs / Links)
+```bash
+ansible web_saas -i ../../../../playbooks/inventory/terraform_cmdb.py -m ping
+```
+
+## 动手改之前先读
+
+- [`terraform-hcl-standard/AGENTS.md`](terraform-hcl-standard/AGENTS.md) —— Terraform 强制约束
+- [`skills/IAC-Spec/SKILL.md`](skills/IAC-Spec/SKILL.md) —— IaC 红线与 IaC ↔ Config-as-Code 边界
+- [`skills/terraform-yaml-render-pattern/SKILL.md`](skills/terraform-yaml-render-pattern/SKILL.md) —— 渲染范式与提交前自检清单
+- [`skills/release-branch-policy/SKILL.md`](skills/release-branch-policy/SKILL.md) —— 分支与发布策略
+
+提交前自检：`terraform fmt` 无 diff、`terraform validate` 通过、`generate.py render` 产出合法 HCL、
+`ansible-inventory --graph` 能解析生成的 inventory、渲染产物与机密未被 stage。
+
+## 已知缺口
+
+- GCP 与 Azure 目前是单文件骨架，且模块命名沿用 AWS，尚不可直接部署。
+- `ali-cloud/config/resources/` 为空，仅有 `envs/dev`。
+- `generate.py` 里 `--resources` 的默认值仍指向拆分前的 `config/resources/ai-workspace-hosts.yaml`，
+  请始终显式传入 `--resources` / `RESOURCES`。
+- 文档归并进度记录在 [`docs/DOC_COVERAGE.md`](docs/DOC_COVERAGE.md)。
+
+## 文档 / 链接
 
 - [官方网站](https://www.svc.plus/)
-- [CloudNativeSuite 文档](https://github.com/ai-workspace-infra)
+- [ai-workspace-infra 组织](https://github.com/ai-workspace-infra)


### PR DESCRIPTION
## What changed

Rewrote `README.md` and `README.zh.md` around what the repository actually contains, organized by IaC module and by classification. The two files are cross-linked bilingual versions, so both were rewritten to stay in sync.

New structure:

- **Core paradigm** — `config/resources/<env>/<group>.yaml` → `generate.py render` → explicit HCL → `terraform apply` → `cmdb_runtime` → `generate.py inventory` → `cmdb.json` + `inventory.ini`, followed by the binding rules that fall out of it (no `for_each`/`count`/`dynamic` in HCL, no topology in HCL, no embedded scripts, state isolated per environment, secrets through env vars + Vault, rendered artifacts not committed).
- **Layers inside a provider tree** — declaration / templates / composition / modules / root modules / run directories / bootstrap, with what is tracked in git for each.
- **Provider maturity** — AWS and Vultr production (Vultr is the reference implementation of the render pattern), Alibaba Cloud partial, GCP and Azure single-file skeletons.
- **Module catalog by domain** — identity & governance / compute / network / data & storage / teardown, compared across all five providers.
- **Environments and resource groups** — `sit` / `uat` / `prod` × `web-saas`, `ai-workspace`, `infra-platform`, `agent-proxy`, `action-runner`, and `all-in-one` (sit only), with the Ansible group each maps to.
- **Components outside Terraform** — `vpn-overlay/`, `skills/`, `scripts/`, `.github/actions/`, `example/`, `docs/`.
- **Quickstart** — bootstrap → render/apply → CMDB → hand over to Ansible, with commands taken from `provision.sh` and the bootstrap `Makefile`.

## Why

The previous README described a cloud-neutral posture the tree does not yet have, and several of its instructions did not work. Corrections made:

- It pointed at `.github/workflows/iac-pipeline-mutli-cloud-*.yaml`, which do not exist. Pipelines live in `.github/actions/`; `workflows/` holds only `validate-release-pr.yml`.
- `cd terraform-hcl-standard/ && terraform init` cannot work — that directory is not a root module, and run directories only exist after a render.
- Terragrunt was listed as `>= 0.50.0`; `aws-cloud/bootstrap/terragrunt.hcl` declares `>= 0.67.14`, and only the AWS bootstrap uses it.
- Bootstrap account YAML is not in this repo (`config/accounts/` holds only `.gitkeep`); it comes from the external GitOps repo via `BOOTSTRAP_CONFIG_PATH` / `TF_VAR_config_root`.
- The old "consistent abstraction across AWS, GCP, Azure, Alibaba Cloud and Vultr" claim hid the fact that GCP and Azure are one-`main.tf`-per-module skeletons using AWS-inherited directory names.

## For reviewers

- Docs only — no Terraform, Python or pipeline changes.
- Branched from `main` rather than continuing on `bugfix/downgrade-vultr-provider`, whose PR #231 is already merged and whose name does not describe this change.
- A "Known gaps" section was added. One item is a real code-level leftover found while verifying the docs: `--resources` in both `aws-cloud/scripts/generate.py` and `vultr-vps/scripts/generate.py` still defaults to the pre-split `config/resources/ai-workspace-hosts.yaml`, which no longer exists. No code was changed here; the README documents it and tells operators to always pass `--resources` / `RESOURCES` explicitly.
- All relative links in both files were checked to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)