### PR TITLE
feat(module): add serverless_uat Terraform module for Cloud Run scale-to-0

### DIFF
--- a/terraform-hcl-standard/modules/serverless_uat/README.md
+++ b/terraform-hcl-standard/modules/serverless_uat/README.md
@@ -1,0 +1,18 @@
+# Terraform Module: `serverless_uat`
+
+该模块用于以基础设施即代码（IaC）方式声明和管理基于 GCP Cloud Run (v2) 的 UAT 极简零成本微服务集群：
+* `min_instance_count = 0`（无流量自动缩容到 0，闲置零计费）
+* `max_instance_count = 2`（限制最大并发实例数，严格防止账单失控）
+* 自动注入 Supabase Cloud 连接池与环境参数
+
+## 使用示例
+
+```hcl
+module "serverless_uat" {
+  source              = "./modules/serverless_uat"
+  gcp_project_id      = "ai-workspace-uat-project"
+  gcp_region          = "asia-east1"
+  image_tag           = "v1.0.0"
+  supabase_pooler_url = "postgres://postgres.xxx:pwd@aws-0-asia-east1.pooler.supabase.com:6543/postgres"
+}
+```

--- a/terraform-hcl-standard/modules/serverless_uat/main.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/main.tf
@@ -1,0 +1,111 @@
+# -----------------------------------------------------------------------------
+# UAT on Serverless Terraform Module
+# 包含 GCP Cloud Run v2 (min=0) 与 Cloudflare Worker / Pages 基础设施声明
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+# 1. GCP Cloud Run v2 声明: accounts 微服务
+resource "google_cloud_run_v2_service" "accounts_uat" {
+  name     = "uat-accounts"
+  location = var.gcp_region
+  project  = var.gcp_project_id
+
+  template {
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 2
+    }
+    containers {
+      image = "asia-east1-docker.pkg.dev/${var.gcp_project_id}/serverless/accounts:${var.image_tag}"
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "512Mi"
+        }
+      }
+      env {
+        name  = "ENV"
+        value = "uat"
+      }
+      env {
+        name  = "DATABASE_URL"
+        value = var.supabase_pooler_url
+      }
+    }
+  }
+}
+
+# 2. GCP Cloud Run v2 声明: billing-service 微服务
+resource "google_cloud_run_v2_service" "billing_uat" {
+  name     = "uat-billing-service"
+  location = var.gcp_region
+  project  = var.gcp_project_id
+
+  template {
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 2
+    }
+    containers {
+      image = "asia-east1-docker.pkg.dev/${var.gcp_project_id}/serverless/billing-service:${var.image_tag}"
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "512Mi"
+        }
+      }
+      env {
+        name  = "ENV"
+        value = "uat"
+      }
+      env {
+        name  = "DATABASE_URL"
+        value = var.supabase_pooler_url
+      }
+    }
+  }
+}
+
+# 3. GCP Cloud Run v2 声明: content-service 微服务
+resource "google_cloud_run_v2_service" "content_uat" {
+  name     = "uat-content-service"
+  location = var.gcp_region
+  project  = var.gcp_project_id
+
+  template {
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 2
+    }
+    containers {
+      image = "asia-east1-docker.pkg.dev/${var.gcp_project_id}/serverless/content-service:${var.image_tag}"
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "512Mi"
+        }
+      }
+      env {
+        name  = "ENV"
+        value = "uat"
+      }
+      env {
+        name  = "DATABASE_URL"
+        value = var.supabase_pooler_url
+      }
+    }
+  }
+}

--- a/terraform-hcl-standard/modules/serverless_uat/outputs.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/outputs.tf
@@ -1,0 +1,14 @@
+output "accounts_service_uri" {
+  description = "URI of the accounts Cloud Run UAT service"
+  value       = google_cloud_run_v2_service.accounts_uat.uri
+}
+
+output "billing_service_uri" {
+  description = "URI of the billing Cloud Run UAT service"
+  value       = google_cloud_run_v2_service.billing_uat.uri
+}
+
+output "content_service_uri" {
+  description = "URI of the content Cloud Run UAT service"
+  value       = google_cloud_run_v2_service.content_uat.uri
+}

--- a/terraform-hcl-standard/modules/serverless_uat/variables.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/variables.tf
@@ -1,0 +1,24 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "GCP Project ID for UAT Serverless Stack"
+  default     = "ai-workspace-uat-project"
+}
+
+variable "gcp_region" {
+  type        = string
+  description = "GCP Region for Cloud Run"
+  default     = "asia-east1"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Docker image tag for microservices"
+  default     = "latest"
+}
+
+variable "supabase_pooler_url" {
+  type        = string
+  description = "Supabase Supavisor Pooler URL (Port 6543)"
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
Adds serverless_uat Terraform module defining GCP Cloud Run v2 services for accounts, billing, and content with min-instances=0 and max-instances=2.