### PR TITLE
feat(uat): wire Golden Image Tokyo snapshots for fast ~3m deployment

### DIFF
--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
@@ -9,6 +9,7 @@ ssh_keys:
 
 hosts:
   - name: agent-proxy-node-uat
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_AGENT_PROXY', 'b6755c99-d9b7-4b69-b0cf-a7b5e57ea18a') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: vc2-1c-2gb
     backups: false

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/ai-workspace.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/ai-workspace.yaml
@@ -9,6 +9,7 @@ ssh_keys:
 
 hosts:
   - name: ai-workspace-node-uat
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '415a1cd7-149f-4f4e-b904-072a179d90dc') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/infra-platform.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/infra-platform.yaml
@@ -9,6 +9,7 @@ ssh_keys:
 
 hosts:
   - name: infra-platform-node-uat
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '415a1cd7-149f-4f4e-b904-072a179d90dc') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
@@ -12,6 +12,7 @@ ssh_keys:
 
 hosts:
   - name: console-nat.{{ env['TARGET_DOMAIN_BASE'] }}
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '415a1cd7-149f-4f4e-b904-072a179d90dc') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true

--- a/terraform-hcl-standard/vultr-vps/scripts/generate.py
+++ b/terraform-hcl-standard/vultr-vps/scripts/generate.py
@@ -120,6 +120,7 @@ def _write_manifest(workdir, hosts):
                 "name": host["name"],
                 "label": host["label"],
                 "source": host.get("_source", ""),
+                "snapshot_id": host.get("snapshot_id", None),
                 "backups": bool(host.get("backups", False)),
                 "backups_schedule": host.get(
                     "backups_schedule", DEFAULT_BACKUPS_SCHEDULE
@@ -270,6 +271,7 @@ def cmd_inventory(args):
             "ip": rt.get("ip"),
             "instance_id": rt.get("instance_id"),
             "os_id": rt.get("os_id"),
+            "snapshot_id": host.get("snapshot_id"),
             "os_name": host.get("os_name", ""),
             "plan": host.get("plan", DEFAULT_PLAN),
             "region": host.get("region") or default_region,

--- a/terraform-hcl-standard/vultr-vps/templates/hosts.tf.j2
+++ b/terraform-hcl-standard/vultr-vps/templates/hosts.tf.j2
@@ -16,7 +16,7 @@ resource "vultr_ssh_key" "{{ key.name | tf_id }}" {
 {% endfor -%}
 {% for host in hosts -%}
 {%- set hid = host.name | tf_id -%}
-{%- if host.os_id is not defined or host.os_id is none %}
+{%- if (host.os_id is not defined or host.os_id is none) and (host.snapshot_id is not defined or host.snapshot_id is none) %}
 data "vultr_os" "{{ hid }}" {
   filter {
     name   = "name"
@@ -37,7 +37,8 @@ module "compute_{{ hid }}" {
   region      = {% if host.region %}"{{ host.region }}"{% else %}var.region{% endif %}
 
   plan        = "{{ host.plan | default('vc2-4c-8gb') }}"
-  os_id       = {% if host.os_id %}{{ host.os_id }}{% else %}data.vultr_os.{{ hid }}.id{% endif %}
+  os_id       = {% if host.snapshot_id %}null{% elif host.os_id %}{{ host.os_id }}{% else %}data.vultr_os.{{ hid }}.id{% endif %}
+  snapshot_id = {% if host.snapshot_id %}"{{ host.snapshot_id }}"{% else %}null{% endif %}
 
   enable_ipv6 = {{ 'true' if host.get('enable_ipv6', true) else 'false' }}
   backups     = {{ 'true' if host.get('backups', false) else 'false' }}
@@ -57,7 +58,7 @@ output "cmdb_runtime" {
     "{{ host.name }}" = {
       ip          = module.compute_{{ hid }}.main_ip
       instance_id = module.compute_{{ hid }}.instance_id
-      os_id       = {% if host.os_id %}{{ host.os_id }}{% else %}data.vultr_os.{{ hid }}.id{% endif %}
+      os_id       = {% if host.snapshot_id %}null{% elif host.os_id %}{{ host.os_id }}{% else %}data.vultr_os.{{ hid }}.id{% endif %}
 
     }
 {% endfor -%}


### PR DESCRIPTION
## Outcome
1. Wires Tokyo Golden Image snapshots into UAT resource declarations (`web-saas.yaml`, `agent-proxy.yaml`, etc.).
2. Supports `snapshot_id` in `hosts.tf.j2` compute module and outputs to boot from Golden Image snapshots.