### PR TITLE
fix(iac): ensure os_id and snapshot_id are rendered with explicit newlines in hosts.tf.j2

### DIFF
--- a/terraform-hcl-standard/vultr-vps/templates/hosts.tf.j2
+++ b/terraform-hcl-standard/vultr-vps/templates/hosts.tf.j2
@@ -37,8 +37,16 @@ module "compute_{{ hid }}" {
   region      = {% if host.region %}"{{ host.region }}"{% else %}var.region{% endif %}
 
   plan        = "{{ host.plan | default('vc2-4c-8gb') }}"
-  os_id       = {% if host.snapshot_id %}null{% elif host.os_id %}{{ host.os_id }}{% else %}data.vultr_os.{{ hid }}.id{% endif %}
-  snapshot_id = {% if host.snapshot_id %}"{{ host.snapshot_id }}"{% else %}null{% endif %}
+{% if host.snapshot_id %}
+  os_id       = null
+  snapshot_id = "{{ host.snapshot_id }}"
+{% elif host.os_id %}
+  os_id       = {{ host.os_id }}
+  snapshot_id = null
+{% else %}
+  os_id       = data.vultr_os.{{ hid }}.id
+  snapshot_id = null
+{% endif %}
 
   enable_ipv6 = {{ 'true' if host.get('enable_ipv6', true) else 'false' }}
   backups     = {{ 'true' if host.get('backups', false) else 'false' }}
@@ -58,8 +66,13 @@ output "cmdb_runtime" {
     "{{ host.name }}" = {
       ip          = module.compute_{{ hid }}.main_ip
       instance_id = module.compute_{{ hid }}.instance_id
-      os_id       = {% if host.snapshot_id %}null{% elif host.os_id %}{{ host.os_id }}{% else %}data.vultr_os.{{ hid }}.id{% endif %}
-
+{% if host.snapshot_id %}
+      os_id       = null
+{% elif host.os_id %}
+      os_id       = {{ host.os_id }}
+{% else %}
+      os_id       = data.vultr_os.{{ hid }}.id
+{% endif %}
     }
 {% endfor -%}
   }


### PR DESCRIPTION
## Outcome
Fixes Terraform initialization syntax error by structuring `os_id` and `snapshot_id` in explicit block statements so they never render on the same line under Jinja2 trim_blocks.