### PR TITLE
fix(vultr): clear stale snapshot id on OS deployments

### DIFF
--- a/terraform-hcl-standard/vultr-vps/modules/compute/main.tf
+++ b/terraform-hcl-standard/vultr-vps/modules/compute/main.tf
@@ -96,6 +96,12 @@ resource "vultr_instance" "this" {
   region      = var.region
   plan        = var.plan
   os_id       = var.os_id
+  # The Vultr provider models snapshot_id as Optional+Computed+ForceNew.  If a
+  # previous instance was created from a Golden Image, leaving this attribute
+  # implicit allows a deleted snapshot ID from state to leak into a later OS
+  # based replacement and fail with "Invalid snapshot".  This module's normal
+  # path is OS-based, so make that intent explicit and clear stale state.
+  snapshot_id = null
   enable_ipv6 = var.enable_ipv6
   backups     = "disabled"
   tags        = var.tags


### PR DESCRIPTION
## Outcome

- Explicitly set `snapshot_id = null` in the Vultr compute module when the normal deployment path supplies `os_id`.
- Prevent a deleted Golden Image snapshot ID persisted by the Vultr provider from leaking into a later replacement request.
- Resolves the `400 Server add failed: Invalid snapshot` failure for `agent-proxy-node-uat`.

## Related

- Failing run: [platform-ops-toolkit run #31824951414](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31824951414).
- Error job: [Prepare | profile + infra](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31824951414/job/94848755761).

## Verification

- Inspected Terraform plan and confirmed the failing resource used snapshot `b6755c99-d9b7-4b69-b0cf-a7b5e57ea18a`.
- `git diff --check` passed.
- Change is isolated to `terraform-hcl-standard/vultr-vps/modules/compute/main.tf`.
- Terraform CLI is not installed locally; CI validation and a real UAT rerun remain required.

## Scope

- No GitHub Actions jobs or dependencies changed.
- Agent Proxy remains `vc2-1c-2gb` and Docker-free.