### PR TITLE
fix(uat): remove stale Golden Image snapshot defaults

### DIFF
--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
@@ -9,7 +9,7 @@ ssh_keys:
 
 hosts:
   - name: agent-proxy-node-uat
-    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_AGENT_PROXY', 'b6755c99-d9b7-4b69-b0cf-a7b5e57ea18a') | tojson }}
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_AGENT_PROXY', '') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: vc2-1c-2gb
     backups: false

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/ai-workspace.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/ai-workspace.yaml
@@ -9,7 +9,7 @@ ssh_keys:
 
 hosts:
   - name: ai-workspace-node-uat
-    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '415a1cd7-149f-4f4e-b904-072a179d90dc') | tojson }}
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/infra-platform.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/infra-platform.yaml
@@ -9,7 +9,7 @@ ssh_keys:
 
 hosts:
   - name: infra-platform-node-uat
-    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '415a1cd7-149f-4f4e-b904-072a179d90dc') | tojson }}
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
@@ -12,7 +12,7 @@ ssh_keys:
 
 hosts:
   - name: console-nat.{{ env['TARGET_DOMAIN_BASE'] }}
-    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '415a1cd7-149f-4f4e-b904-072a179d90dc') | tojson }}
+    snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_WEBSAAS', '') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
     plan: {{ env.get('INSTANCE_PLAN_API', 'vc2-4c-8gb') }}
     backups: true


### PR DESCRIPTION
## Outcome

- Remove hard-coded Vultr Golden Image UUID fallbacks from all UAT Vultr resource profiles.
- Snapshot IDs are now supplied by the deployment workflow; an absent ID renders the existing Debian OS fallback instead of a deleted snapshot UUID.
- Keep the existing Golden Image Terraform support and `vc2-1c-2gb` Agent Proxy plan unchanged.

## Related

- Failing run: [platform-ops-toolkit run #31824951414](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31824951414).
- Error job: [Prepare | profile + infra](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/31824951414/job/94848755761).
- Supersedes the closed [PR #238](https://github.com/ai-workspace-infra/iac_modules/pull/238).

## Verification

- `git diff --check` passed.
- Confirmed all four UAT profiles now default to an empty snapshot ID.
- Terraform syntax/validation remains a CI responsibility because Terraform CLI is not installed locally.

## Scope

- No jobs or workflow dependencies changed.
- Agent Proxy remains Docker-free.