### PR TITLE
feat(vultr): make Agent Proxy runtime plan configurable

### DIFF
--- a/terraform-hcl-standard/aws-cloud/config/resources/prod/agent-proxy.yaml
+++ b/terraform-hcl-standard/aws-cloud/config/resources/prod/agent-proxy.yaml
@@ -10,7 +10,9 @@ ssh_keys:
 hosts:
   - name: agent-proxy-node-prod
     os_name: "Debian 13 x64 (trixie)"
-    plan: t4g.small
+    # Keep the lightweight Agent Proxy default at 1C1G (t4g.micro). Callers
+    # may override it with AGENT_PROXY_PLAN_API when a larger node is needed.
+    plan: {{ env.get('AGENT_PROXY_PLAN_API', 't4g.micro') }}
     backups: false
     enable_ipv6: true
     ansible_user: root

--- a/terraform-hcl-standard/aws-cloud/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/aws-cloud/config/resources/uat/agent-proxy.yaml
@@ -10,7 +10,9 @@ ssh_keys:
 hosts:
   - name: agent-proxy-node-uat
     os_name: "Debian 13 x64 (trixie)"
-    plan: t4g.small
+    # Keep the lightweight Agent Proxy default at 1C1G (t4g.micro). Callers
+    # may override it with AGENT_PROXY_PLAN_API when a larger node is needed.
+    plan: {{ env.get('AGENT_PROXY_PLAN_API', 't4g.micro') }}
     backups: false
     enable_ipv6: true
     ansible_user: root

--- a/terraform-hcl-standard/vultr-vps/config/resources/prod/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/prod/agent-proxy.yaml
@@ -10,7 +10,10 @@ ssh_keys:
 hosts:
   - name: agent-proxy-node-prod
     os_name: "Debian 13 x64 (trixie)"
-    plan: vc2-1c-2gb
+    # Agent Proxy is a lightweight native systemd workload. Keep the runtime
+    # default at 1C1G; callers may override it with AGENT_PROXY_PLAN_API when
+    # a larger node is required.
+    plan: {{ env.get('AGENT_PROXY_PLAN_API', 'vc2-1c-1gb') }}
     backups: false
     enable_ipv6: true
     ansible_user: root

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
@@ -11,7 +11,10 @@ hosts:
   - name: agent-proxy-node-uat
     snapshot_id: {{ env.get('SNAPSHOT_ID_DEBIAN13_AGENT_PROXY', 'b6755c99-d9b7-4b69-b0cf-a7b5e57ea18a') | tojson }}
     os_name: "Debian 13 x64 (trixie)"
-    plan: vc2-1c-2gb
+    # Agent Proxy is a lightweight native systemd workload. Keep the runtime
+    # default at 1C1G; callers may override it with AGENT_PROXY_PLAN_API when
+    # a larger node is required.
+    plan: {{ env.get('AGENT_PROXY_PLAN_API', 'vc2-1c-1gb') }}
     backups: false
     enable_ipv6: true
     ansible_user: root


### PR DESCRIPTION
## Outcome
- Make Agent Proxy runtime size configurable instead of hardcoded.
- Default is 1C1G (`vc2-1c-1gb` on Vultr, `t4g.micro` on AWS); dispatch can explicitly select 1C2G.
- Golden Image build plans are unchanged.

## Issue
- Follow-up to the Agent Proxy runtime sizing request; no external issue was provided.

## Verification
- Rendered Vultr UAT Agent Proxy YAML with default and 1C2G override.
- Rendered AWS UAT Agent Proxy YAML with the 1C1G default.
- Confirmed generated Terraform plan values are correct.