### PR TITLE
feat(iac): add Supabase Cloud Terraform support

### DIFF
--- a/terraform-hcl-standard/supabase-cloud/README.md
+++ b/terraform-hcl-standard/supabase-cloud/README.md
@@ -1,0 +1,72 @@
+# Supabase Cloud Terraform support
+
+This provider tree adds Supabase Cloud support to the repository's YAML-driven
+IaC layout. It follows the repository's declaration → render → Terraform
+workdir pattern and uses the official `supabase/supabase` provider.
+
+## What is managed
+
+- `supabase_project.this`: creates or imports a Supabase project.
+- `supabase_pooler.this`: reads the official Session/Transaction Pooler URIs.
+- `connection`: exposes the standard downstream contract:
+  `username`, `database`, `uri`, and selected `mode`.
+
+The provider manages the project and connection metadata; it does not create
+arbitrary PostgreSQL users. Supabase's project database user is supplied by the
+connection string returned by Supabase.
+
+## Configuration contract
+
+Declare non-secret values in `config/resources/<env>/supabase.yaml`:
+
+```yaml
+global:
+  project_ref: "{{ env.get('SUPABASE_PROJECT_REF', '') }}" # omit for a new project
+  organization_id: "{{ env.get('SUPABASE_ORGANIZATION_ID', '') }}"
+  project_name: "ai-workspace-dev"
+  region: "ap-southeast-1"
+  instance_size: "micro"
+  pooler_mode: "session"
+
+database:
+  username: "{{ env.get('SUPABASE_DATABASE_USERNAME', 'postgres') }}"
+  name: "postgres"
+  uri_env: "SUPABASE_DATABASE_DIRECT_URL"
+```
+
+Do not put `SUPABASE_ACCESS_TOKEN`, database passwords, or connection URIs in
+YAML, generated tfvars, or committed Terraform. Inject them from Vault/CI:
+
+```bash
+export SUPABASE_ACCESS_TOKEN="..."
+export TF_VAR_database_password="..."
+export TF_VAR_database_uri="postgresql://..." # optional Direct URI
+```
+
+`SUPABASE_PROJECT_REF` is optional when creating a new project and required
+when adopting an existing project. `TF_VAR_database_uri` is optional. If
+omitted, `database_uri` uses the configured Supavisor mode. Session mode
+(`5432`) is the default for persistent
+VPS backends; Transaction mode (`6543`) is intended for serverless clients that
+have disabled prepared statements. Use a Direct URI for migrations and
+backups.
+
+## Standard init
+
+From this directory:
+
+```bash
+./scripts/init.sh
+terraform -chdir=envs/dev plan
+terraform -chdir=envs/dev apply
+terraform -chdir=envs/dev output -raw database_uri
+```
+
+`init.sh` renders the YAML and runs `terraform init`. When `project_ref` is
+present, the renderer also writes an `import.tf` import block so an existing
+Supabase project is adopted into state during the first plan/apply. The
+generated files and state stay in `envs/<env>` and are ignored by Git.
+
+For local Supabase CLI development, initialize the application repository
+separately with `supabase init`; that local stack is not the Terraform-managed
+Supabase Cloud project.

--- a/terraform-hcl-standard/supabase-cloud/config/resources/dev/supabase.yaml
+++ b/terraform-hcl-standard/supabase-cloud/config/resources/dev/supabase.yaml
@@ -1,0 +1,16 @@
+# Supabase Cloud project declaration.
+# Keep passwords and URIs out of this file. Inject them through Vault-backed
+# SUPABASE_ACCESS_TOKEN, TF_VAR_database_password and optionally
+# TF_VAR_database_uri in the deployment environment.
+global:
+  project_ref: "{{ env.get('SUPABASE_PROJECT_REF', '') }}"
+  organization_id: "{{ env.get('SUPABASE_ORGANIZATION_ID', '') }}"
+  project_name: "ai-workspace-dev"
+  region: "ap-southeast-1"
+  instance_size: "micro"
+  pooler_mode: "session"
+
+database:
+  username: "{{ env.get('SUPABASE_DATABASE_USERNAME', 'postgres') }}"
+  name: "postgres"
+  uri_env: "SUPABASE_DATABASE_DIRECT_URL"

--- a/terraform-hcl-standard/supabase-cloud/envs/dev/.gitignore
+++ b/terraform-hcl-standard/supabase-cloud/envs/dev/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/terraform-hcl-standard/supabase-cloud/envs/dev/README.md
+++ b/terraform-hcl-standard/supabase-cloud/envs/dev/README.md
@@ -1,0 +1,23 @@
+# Supabase Cloud dev workdir
+
+This directory is a Terraform run directory. Render it from the resource
+declaration instead of adding hand-written Terraform files here.
+
+```bash
+export SUPABASE_ACCESS_TOKEN="..."
+export SUPABASE_PROJECT_REF="abcdefghijklmnopqrst"
+export SUPABASE_ORGANIZATION_ID="your-org-slug"
+export TF_VAR_database_password="..."
+
+./scripts/init.sh
+terraform -chdir=envs/dev plan
+terraform -chdir=envs/dev apply
+terraform -chdir=envs/dev output -raw database_uri
+```
+
+For an existing project, `init.sh` renders an import block from
+`SUPABASE_PROJECT_REF`; `terraform plan` then imports and reconciles the
+project. Omit that variable to create a new project. The direct URI is
+optional and should be injected as `TF_VAR_database_uri` from Vault. Without
+it, `database_uri` selects the configured Supavisor mode (`session` by
+default).

--- a/terraform-hcl-standard/supabase-cloud/main.tf
+++ b/terraform-hcl-standard/supabase-cloud/main.tf
@@ -1,0 +1,32 @@
+locals {
+  effective_project_ref = coalesce(var.project_ref, supabase_project.this.id)
+  has_explicit_database_uri = try(trimspace(var.database_uri), "") != ""
+  configured_database_uri = (
+    local.has_explicit_database_uri
+    ? var.database_uri
+    : lookup(data.supabase_pooler.this.url, var.pooler_mode, "")
+  )
+}
+
+# Supabase projects are importable and can also be created by this resource.
+# database_password is intentionally ignored after the first apply: Supabase
+# owns the live password and the secret must not be rotated by an accidental
+# tfvars change.
+resource "supabase_project" "this" {
+  organization_id   = var.organization_id
+  name              = var.project_name
+  database_password = var.database_password
+  region            = var.region
+  instance_size     = var.instance_size
+
+  lifecycle {
+    ignore_changes = [database_password]
+  }
+}
+
+# The provider exposes the official Supavisor connection strings. The data
+# source returns session and transaction URLs; the chosen one is surfaced via
+# a sensitive output for Vault/deployment consumers.
+data "supabase_pooler" "this" {
+  project_ref = local.effective_project_ref
+}

--- a/terraform-hcl-standard/supabase-cloud/outputs.tf
+++ b/terraform-hcl-standard/supabase-cloud/outputs.tf
@@ -1,0 +1,27 @@
+output "project_ref" {
+  description = "Supabase project reference."
+  value       = local.effective_project_ref
+}
+
+output "pooler_uris" {
+  description = "Supavisor connection URIs keyed by session and transaction mode."
+  value       = data.supabase_pooler.this.url
+  sensitive   = true
+}
+
+output "database_uri" {
+  description = "Selected database URI: explicit database_uri, otherwise the selected Supavisor mode."
+  value       = local.configured_database_uri
+  sensitive   = true
+}
+
+output "connection" {
+  description = "Database connection contract for downstream deployment consumers."
+  value = {
+    username = var.database_username
+    database = var.database_name
+    uri      = local.configured_database_uri
+    mode     = local.has_explicit_database_uri ? "explicit" : var.pooler_mode
+  }
+  sensitive = true
+}

--- a/terraform-hcl-standard/supabase-cloud/provider.tf
+++ b/terraform-hcl-standard/supabase-cloud/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    supabase = {
+      source  = "supabase/supabase"
+      version = "~> 1.0"
+    }
+  }
+}
+
+# The provider reads SUPABASE_ACCESS_TOKEN from the environment. Keeping the
+# block argument-free prevents the token from being copied into tfvars/state.
+provider "supabase" {}

--- a/terraform-hcl-standard/supabase-cloud/scripts/init.sh
+++ b/terraform-hcl-standard/supabase-cloud/scripts/init.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUPABASE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RESOURCES="${RESOURCES:-${SUPABASE_ROOT}/config/resources/dev/supabase.yaml}"
+WORKDIR="${WORKDIR:-${SUPABASE_ROOT}/envs/dev}"
+
+command -v terraform >/dev/null 2>&1 || {
+  echo "terraform is required; install Terraform >= 1.5.0 first" >&2
+  exit 1
+}
+
+echo "==> render Supabase declaration"
+python3 "${SCRIPT_DIR}/render.py" render --resources "${RESOURCES}" --workdir "${WORKDIR}"
+
+# Keep the direct URI in the process environment only. This accepts the
+# declaration's URI environment variable without writing it to YAML or
+# terraform.auto.tfvars.json.
+URI_ENV="$(python3 "${SCRIPT_DIR}/render.py" uri-env --resources "${RESOURCES}")"
+if [[ ! "${URI_ENV}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+  echo "invalid database.uri_env name: ${URI_ENV}" >&2
+  exit 1
+fi
+if [[ -z "${TF_VAR_database_uri:-}" && -n "${!URI_ENV:-}" ]]; then
+  export TF_VAR_database_uri="${!URI_ENV}"
+fi
+
+echo "==> terraform init"
+terraform -chdir="${WORKDIR}" init -input=false
+
+echo "==> Supabase Terraform workdir initialized"
+echo "next: terraform -chdir=\"${WORKDIR}\" plan"

--- a/terraform-hcl-standard/supabase-cloud/scripts/render.py
+++ b/terraform-hcl-standard/supabase-cloud/scripts/render.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Render a Supabase YAML declaration into a Terraform work directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+
+import yaml
+from jinja2 import Template
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_FILES = ["provider.tf", "variables.tf", "main.tf", "outputs.tf"]
+DEFAULT_RESOURCES = ROOT / "config" / "resources" / "dev" / "supabase.yaml"
+DEFAULT_WORKDIR = ROOT / "envs" / "dev"
+
+
+def load_declaration(path: Path) -> dict:
+    rendered = Template(path.read_text(encoding="utf-8")).render(env=os.environ)
+    data = yaml.safe_load(rendered) or {}
+    global_config = data.get("global") or {}
+    database = data.get("database") or {}
+
+    required = {
+        "global.organization_id": global_config.get("organization_id"),
+        "global.project_name": global_config.get("project_name"),
+        "global.region": global_config.get("region"),
+        "database.username": database.get("username"),
+        "database.name": database.get("name"),
+    }
+    missing = [name for name, value in required.items() if not str(value or "").strip()]
+    if missing:
+        raise SystemExit(
+            f"{path}: missing required declaration value(s): {', '.join(missing)}. "
+            "Use environment variables for organization_id and optionally project_ref."
+        )
+
+    return {"global": global_config, "database": database}
+
+
+def render(args: argparse.Namespace) -> None:
+    resources = Path(args.resources).expanduser().resolve()
+    workdir = Path(args.workdir).expanduser().resolve()
+    data = load_declaration(resources)
+    global_config = data["global"]
+    database = data["database"]
+
+    workdir.mkdir(parents=True, exist_ok=True)
+    for filename in TEMPLATE_FILES:
+        shutil.copyfile(ROOT / filename, workdir / filename)
+
+    project_ref = str(global_config.get("project_ref") or "").strip()
+    tfvars = {
+        "project_ref": project_ref,
+        "organization_id": str(global_config["organization_id"]).strip(),
+        "project_name": str(global_config["project_name"]).strip(),
+        "region": str(global_config["region"]).strip(),
+        "instance_size": global_config.get("instance_size"),
+        "database_username": str(database["username"]).strip(),
+        "database_name": str(database["name"]).strip(),
+        "pooler_mode": str(global_config.get("pooler_mode", "session")).strip(),
+    }
+    (workdir / "terraform.auto.tfvars.json").write_text(
+        json.dumps(tfvars, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    import_file = workdir / "import.tf"
+    if project_ref:
+        import_file.write_text(
+            "import {\n"
+            "  to = supabase_project.this\n"
+            f'  id = "{project_ref}"\n'
+            "}\n",
+            encoding="utf-8",
+        )
+    elif import_file.exists():
+        import_file.unlink()
+
+    uri_env = database.get("uri_env", "SUPABASE_DATABASE_DIRECT_URL")
+    print(f"resources: {resources}")
+    print(f"workdir:   {workdir}")
+    print(f"wrote:     {', '.join(TEMPLATE_FILES)}, terraform.auto.tfvars.json")
+    if project_ref:
+        print(f"wrote:     import.tf (project {project_ref})")
+    print(
+        "database URI: inject TF_VAR_database_uri when using the direct URI; "
+        f"declaration hint: {uri_env}"
+    )
+
+
+def print_uri_env(args: argparse.Namespace) -> None:
+    resources = Path(args.resources).expanduser().resolve()
+    data = load_declaration(resources)
+    print(data["database"].get("uri_env", "SUPABASE_DATABASE_DIRECT_URL"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    render_parser = subparsers.add_parser("render", help="YAML -> Terraform workdir")
+    render_parser.add_argument("--resources", type=Path, default=DEFAULT_RESOURCES)
+    render_parser.add_argument("--workdir", type=Path, default=DEFAULT_WORKDIR)
+    render_parser.set_defaults(func=render)
+    uri_parser = subparsers.add_parser("uri-env", help="print the URI environment variable name")
+    uri_parser.add_argument("--resources", type=Path, default=DEFAULT_RESOURCES)
+    uri_parser.set_defaults(func=print_uri_env)
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, yaml.YAMLError) as exc:
+        print(f"render failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/terraform-hcl-standard/supabase-cloud/variables.tf
+++ b/terraform-hcl-standard/supabase-cloud/variables.tf
@@ -1,0 +1,64 @@
+variable "project_ref" {
+  description = "Existing Supabase project reference. Set this for import and connection discovery."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "organization_id" {
+  description = "Supabase organization slug used when creating a project."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Supabase project name."
+  type        = string
+}
+
+variable "region" {
+  description = "Supabase database region."
+  type        = string
+}
+
+variable "instance_size" {
+  description = "Optional Supabase compute instance size."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "database_password" {
+  description = "Supabase database password, injected from Vault or TF_VAR_database_password."
+  type        = string
+  sensitive   = true
+}
+
+variable "database_username" {
+  description = "Database user name used by the application connection contract."
+  type        = string
+}
+
+variable "database_name" {
+  description = "Database name used by the application connection contract."
+  type        = string
+  default     = "postgres"
+}
+
+variable "database_uri" {
+  description = "Optional direct/database URI from Vault. When unset, the selected Supavisor URI is used."
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "pooler_mode" {
+  description = "Supavisor URI to expose when database_uri is not supplied: session or transaction."
+  type        = string
+  default     = "session"
+
+  validation {
+    condition     = contains(["session", "transaction"], var.pooler_mode)
+    error_message = "pooler_mode must be session or transaction."
+  }
+}


### PR DESCRIPTION
## What changed

- Add a `supabase-cloud` Terraform provider tree using the official `supabase/supabase` provider.
- Support Supabase project creation/import and Pooler URI discovery.
- Add YAML configuration for `database.username`, `database.name`, `database.uri_env`, and session/transaction pooler mode.
- Keep access tokens, database passwords, and URIs out of YAML/tfvars; inject them through environment variables or Vault.
- Add standard `scripts/init.sh` and renderer workflow.

## Validation

- YAML render checked for existing-project import and new-project paths.
- Generated tfvars contain no database URI/password.
- HCL parsed successfully.
- Shell syntax and Python compilation passed.
- Terraform CLI `init/validate` was not run because Terraform was unavailable in the environment.
