### PR TITLE
fix(supabase): use Tokyo debug project region

### DIFF
--- a/terraform-hcl-standard/supabase-cloud/config/resources/dev/supabase.yaml
+++ b/terraform-hcl-standard/supabase-cloud/config/resources/dev/supabase.yaml
@@ -6,7 +6,7 @@ global:
   project_ref: "{{ env.get('SUPABASE_PROJECT_REF', '') }}"
   organization_id: "{{ env.get('SUPABASE_ORGANIZATION_ID', '') }}"
   project_name: "ai-workspace-dev"
-  region: "ap-southeast-1"
+  region: "ap-northeast-1"
   instance_size: "micro"
   pooler_mode: "session"
 


### PR DESCRIPTION
## Summary
- set the dev Supabase declaration region to `ap-northeast-1`
- align the Terraform declaration with the debug project shown in the Supabase dashboard

## Validation
- `git diff --check`

The Supabase provider/IAC support is already merged in PR #242; this PR only corrects the environment declaration.