### PR TITLE
fix: enforce SIT and UAT DNS topology

### DIFF
--- a/terraform-hcl-standard/vultr-vps/config/resources/sit/all-in-one.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/sit/all-in-one.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# ai-workspace 资源描述 (CMDB 源数据)
+# SIT all-in-one 资源描述 (CMDB 源数据)
 #
 # 这是唯一的人工维护入口。generate.py 读取本文件：
 #   - global 段  -> terraform.auto.tfvars.json (传给 variables.tf)
@@ -22,28 +22,17 @@ ssh_keys:
 # 主机清单。map key 风格用 name 字段；每台机器渲染成一个独立 module 块。
 hosts:
   - name: ai-debian13
-    os_name: "Debian 13 x64 (trixie)"   # Vultr 实际镜像名（含 trixie）；也可写 os_id: 2625
-    plan: vc2-4c-8gb              # 2 核 4G（临时缩配，验证后改回 vc2-4c-8gb）
+    os_name: "Debian 13 x64 (trixie)"
+    plan: vc2-4c-8gb
     backups: true                # 开启备份以保护数据库
     enable_ipv6: true             # 公网 IPv4 默认分配，这里附带开 IPv6
     ansible_user: root
-    groups: [ai_workspace, debian, database]
-    tags: [debian, database]
+    groups: [all_in_one, web_saas, agent_proxy, ai_workspace, infra_platform, debian, database]
+    tags: [all-in-one, sit, web-saas, agent-proxy, ai-workspace, infra-platform, debian, database]
     host_vars:
       role: primary
-      # 逗号分隔的服务域名；cloudflare_dns 角色据此为本机 IP 建 A 记录
-      service_domains: 
-        - xworkmate-bridge-debian-13.{{ env['TARGET_DOMAIN_BASE'] }}
-        - postgresql-ai-workspace.{{ env['TARGET_DOMAIN_BASE'] }}
-
-  - name: ai-ubuntu2604
-    os_name: "Ubuntu 26.04 LTS x64"
-    plan: vc2-4c-8gb
-    backups: false
-    enable_ipv6: true
-    ansible_user: root
-    groups: [ai_workspace, ubuntu]
-    tags: [ubuntu]
-    host_vars:
-      role: secondary
-      service_domains: xworkmate-bridge-ubuntu-26.{{ env['TARGET_DOMAIN_BASE'] }}
+      service_domains:
+        - console-vps-sit.{{ env['TARGET_DOMAIN_BASE'] }}
+        - accounts-vps-sit.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-vps-sit.{{ env['TARGET_DOMAIN_BASE'] }}
+        - agent-proxy-sit.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
@@ -23,4 +23,4 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - agent-proxy.{{ env['TARGET_DOMAIN_BASE'] }}
+        - agent-proxy-uat.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/scripts/generate.py
+++ b/terraform-hcl-standard/vultr-vps/scripts/generate.py
@@ -298,6 +298,42 @@ def cmd_inventory(args):
             + "\n".join(problems)
         )
 
+    # Web SaaS is intentionally a co-located full-stack host, so its Console,
+    # Accounts and PostgreSQL aliases may share one IP.  The safety boundary is
+    # between the web_saas role and the separate agent_proxy role: if those two
+    # roles share an IP, Ansible can silently deploy the agent role onto the
+    # Web SaaS host and DNS reconciliation can publish the wrong address.
+    role_ip_owners = {"web_saas": {}, "agent_proxy": {}}
+    for fqdn, host in cmdb.items():
+        ip = str(host.get("ip") or "").strip()
+        if not ip:
+            continue
+        for role in role_ip_owners:
+            if role in (host.get("groups") or []):
+                role_ip_owners[role].setdefault(ip, []).append(fqdn)
+
+    cross_role_ips = sorted(
+        set(role_ip_owners["web_saas"]) & set(role_ip_owners["agent_proxy"])
+    )
+    sit_all_in_one = (
+        any(
+            os.path.basename(os.path.dirname(os.path.normpath(resource))) == "sit"
+            and os.path.basename(os.path.normpath(resource)) == "all-in-one.yaml"
+            for resource in args.resources.split(",")
+        )
+    )
+    if cross_role_ips and not sit_all_in_one:
+        details = [
+            f"  - {ip}: web_saas={', '.join(role_ip_owners['web_saas'][ip])}; "
+            f"agent_proxy={', '.join(role_ip_owners['agent_proxy'][ip])}"
+            for ip in cross_role_ips
+        ]
+        sys.exit(
+            "CMDB role/IP 校验失败：web_saas 与 agent_proxy 共享同一个运行时 IP；"
+            "请检查 Terraform workspace/state 与 cmdb_runtime 映射后再部署：\n"
+            + "\n".join(details)
+        )
+
     with open(os.path.join(workdir, "cmdb.json"), "w", encoding="utf-8") as fh:
         json.dump(cmdb, fh, indent=2, ensure_ascii=False)
         fh.write("\n")


### PR DESCRIPTION
## Outcome

Correct SIT all-in-one topology and enforce the UAT separation between Web SaaS and Agent Proxy runtime IPs.

## Issue

- N/A — generated UAT CMDB mapped the Agent Proxy deployment to the Web SaaS host; the routing correction is tracked in this task.

## Scope

- Make SIT `all-in-one.yaml` a single mixed-role host with the four `*-sit` DNS service domains.
- Allow shared Web SaaS/Agent Proxy IPs only for the explicit SIT all-in-one profile.
- Reject cross-role IP collisions for UAT and other separated deployments.
- Update the UAT Agent Proxy service domain to `agent-proxy-uat`.
- Do not include unrelated README or Contabo changes from the working tree.

## Verification

- `python3 -m py_compile terraform-hcl-standard/vultr-vps/scripts/generate.py` — passed.
- Resource YAML was inspected against the render contract; full Python render was not run because the local Python environment lacks `jinja2`.

## Risk / Security / Configuration

- Terraform resource topology changes the SIT profile from two hosts to one all-in-one host.
- UAT cross-role IP collisions now fail before Ansible/DNS deployment.
- No credentials, tokens, or secret values are changed.

## Rollback

Revert this PR, then rerun the affected environment's Terraform plan before applying.

## Related

- Companion PR: platform-ops-toolkit `bugfix/uat-sit-dns-routing` (must merge after this IaC PR): pending.
- Merge this IaC PR before the platform-ops-toolkit companion PR.
