### PR TITLE
Declare UAT VPS service domains

### DIFF
--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/agent-proxy.yaml
@@ -23,4 +23,4 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - agent-proxy-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        - agent-proxy-vps-uat.{{ env['TARGET_DOMAIN_BASE'] }}

--- a/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
+++ b/terraform-hcl-standard/vultr-vps/config/resources/uat/web-saas.yaml
@@ -23,13 +23,13 @@ hosts:
     host_vars:
       role: primary
       service_domains:
-        - console-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        - console-vps-uat.{{ env['TARGET_DOMAIN_BASE'] }}
         # accounts 是 web-saas 栈里独立的对外站点: Caddyfile 给它单独一个
         # https:// 块(OAuth 回调固定落在这里, console 只是发起跳转的一方)。
         # 少了这条 A 记录, Caddy 的 ACME HTTP-01 验证拿不到解析、签不出证书,
         # 而 console 那个站点照常可用 —— 于是表现成"登录跳转过去就白屏"。
-        - accounts-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        - accounts-vps-uat.{{ env['TARGET_DOMAIN_BASE'] }}
         # Billing job trigger 只允许 agent-proxy 通过 web-saas Caddy 访问；
         # 该域名与 agent-proxy CIDR matcher 配套生成。
-        - billing-uat.{{ env['TARGET_DOMAIN_BASE'] }}
-        - postgresql-saas-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        - billing-vps-uat.{{ env['TARGET_DOMAIN_BASE'] }}
+        - postgresql-vps-uat.{{ env['TARGET_DOMAIN_BASE'] }}


### PR DESCRIPTION
## Outcome

Declare the UAT Selfhost VPS deployment-domain names used by DNS reconciliation and internal service routing.

## Issue

- Related to the UAT topology correction where Web SaaS and Agent Proxy must not share an IP, while public aliases resolve through the declared VPS service names.

## Scope

- Web SaaS declares `console-vps-uat`, `accounts-vps-uat`, `billing-vps-uat`, and `postgresql-vps-uat`.
- Agent Proxy declares `agent-proxy-vps-uat`.
- SIT and production declarations are unchanged.

## Verification

- `git diff --check` — passed.
- Resource declarations reviewed against the UAT Selfhost VPS topology.
- Terraform apply and generated-CMDB verification are pending merge and deployment.

## Risk / Security / Configuration

- Changes generated UAT service-domain names and therefore the DNS reconciliation inputs.
- No credentials, state files, or secrets are changed.

## Rollback

Revert this PR and rerun the UAT infrastructure generation with the previous service-domain declarations.

## Related

- GitOps UAT selfhost topology already selects `console-uat -> console-vps-uat` and `accounts-uat -> accounts-vps-uat`.
- Platform Ops PR updates the DNS reconciler and deployment consumers.
