### PR TITLE
feat: manage Cloudflare Billing origin alias

### DIFF
--- a/terraform-hcl-standard/modules/serverless_uat/README.md
+++ b/terraform-hcl-standard/modules/serverless_uat/README.md
@@ -14,5 +14,13 @@ module "serverless_uat" {
   gcp_region          = "asia-east1"
   image_tag           = "v1.0.0"
   supabase_pooler_url = "postgres://postgres.xxx:pwd@aws-0-asia-east1.pooler.supabase.com:6543/postgres"
+  cloudflare_zone_id  = "eab572e5680befe7e00c6d5ff966b050"
+  billing_origin_host = "billing-origin-serverless-uat.onwalk.net"
 }
 ```
+
+The module creates the Billing origin alias as a DNS-only CNAME to the deployed
+Cloud Run service. The public `billing-serverless-uat.onwalk.net` record remains
+the proxied application entry. Cloudflare Origin Rules use the alias for
+`origin.host`, while the Cloud Run `run.app` hostname remains the Host header and
+TLS SNI. Do not use a Cloud Run domain mapping for this path.

--- a/terraform-hcl-standard/modules/serverless_uat/main.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/main.tf
@@ -109,3 +109,15 @@ resource "google_cloud_run_v2_service" "content_uat" {
     }
   }
 }
+
+# 4. Cloudflare DNS-only origin alias for the Billing Origin Rule.
+# The public billing hostname remains proxied; this same-zone alias is used
+# only for Cloudflare's DNS record override and must never be proxied.
+resource "cloudflare_record" "billing_origin" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.billing_origin_host
+  content = replace(google_cloud_run_v2_service.billing_uat.uri, "https://", "")
+  type    = "CNAME"
+  ttl     = 60
+  proxied = false
+}

--- a/terraform-hcl-standard/modules/serverless_uat/outputs.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/outputs.tf
@@ -12,3 +12,13 @@ output "content_service_uri" {
   description = "URI of the content Cloud Run UAT service"
   value       = google_cloud_run_v2_service.content_uat.uri
 }
+
+output "billing_origin_host" {
+  description = "DNS-only Cloudflare hostname used for the Billing origin override"
+  value       = cloudflare_record.billing_origin.name
+}
+
+output "billing_origin_target" {
+  description = "Cloud Run hostname targeted by the Billing origin alias"
+  value       = cloudflare_record.billing_origin.content
+}

--- a/terraform-hcl-standard/modules/serverless_uat/variables.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/variables.tf
@@ -22,3 +22,14 @@ variable "supabase_pooler_url" {
   sensitive   = true
   default     = ""
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID containing the serverless Billing origin alias"
+}
+
+variable "billing_origin_host" {
+  type        = string
+  description = "DNS-only same-zone hostname used by the Cloudflare Billing Origin Rule"
+  default     = "billing-origin-serverless-uat.onwalk.net"
+}


### PR DESCRIPTION
## Outcome

Extend the `serverless_uat` Terraform module to create the DNS-only same-zone Billing origin alias required by the Cloudflare Origin Rule.

## Issue

- [Serverless Orchestrator failure job](https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32198428682/job/95909479148)
- [GitOps serverless origin alias contract](https://github.com/ai-workspace-infra/gitops/pull/165)

## Scope

- Added a Cloudflare DNS-only CNAME resource targeting the deployed Billing Cloud Run hostname.
- Added `cloudflare_zone_id` and `billing_origin_host` inputs plus outputs for the managed alias and target.
- Updated module usage documentation.
- The module does not create a Cloud Run custom domain mapping and does not change the public proxied Billing record.

## Verification

- `git diff --check` — passed.
- Terraform `fmt`/`validate` — not run locally because the Terraform CLI is not installed in the workspace; CI must run these checks.

## Risk / Security / Configuration

- Callers must provide the Cloudflare zone ID and provider credentials with DNS write permission.
- The managed record is explicitly `proxied = false`; no secrets are stored in the module.

## Rollback

Revert this PR and remove the alias record from the Terraform state through the normal reviewed Terraform workflow.

## Related

- Merge after [gitops#165](https://github.com/ai-workspace-infra/gitops/pull/165) and before [platform-ops-toolkit#420](https://github.com/ai-workspace-infra/platform-ops-toolkit/pull/420).
- Companion [playbooks#374](https://github.com/ai-workspace-infra/playbooks/pull/374) reconciles the same alias for Ansible-driven runs.
