### PR TITLE
fix: bind Billing to core Edge Worker

### DIFF
--- a/terraform-hcl-standard/modules/serverless_uat/README.md
+++ b/terraform-hcl-standard/modules/serverless_uat/README.md
@@ -14,13 +14,13 @@ module "serverless_uat" {
   gcp_region          = "asia-east1"
   image_tag           = "v1.0.0"
   supabase_pooler_url = "postgres://postgres.xxx:pwd@aws-0-asia-east1.pooler.supabase.com:6543/postgres"
+  cloudflare_account_id = "e71be5efb76a6c54f78f008da4404f00"
   cloudflare_zone_id  = "eab572e5680befe7e00c6d5ff966b050"
-  billing_origin_host = "billing-origin-serverless-uat.onwalk.net"
+  billing_host        = "billing-serverless-uat.onwalk.net"
+  edge_gateway_core_worker = "edge-gateway-core-uat"
 }
 ```
 
-The module creates the Billing origin alias as a DNS-only CNAME to the deployed
-Cloud Run service. The public `billing-serverless-uat.onwalk.net` record remains
-the proxied application entry. Cloudflare Origin Rules use the alias for
-`origin.host`, while the Cloud Run `run.app` hostname remains the Host header and
-TLS SNI. Do not use a Cloud Run domain mapping for this path.
+The module attaches the public Billing hostname to the core Edge Gateway Worker.
+That Worker proxies to the deployed Cloud Run service. This path requires neither
+a Cloud Run domain mapping nor Cloudflare's Enterprise-only Host/SNI Origin Rule.

--- a/terraform-hcl-standard/modules/serverless_uat/main.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/main.tf
@@ -12,7 +12,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.0.0"
+      version = ">= 4.52.0, < 5.0.0"
     }
   }
 }
@@ -110,14 +110,12 @@ resource "google_cloud_run_v2_service" "content_uat" {
   }
 }
 
-# 4. Cloudflare DNS-only origin alias for the Billing Origin Rule.
-# The public billing hostname remains proxied; this same-zone alias is used
-# only for Cloudflare's DNS record override and must never be proxied.
-resource "cloudflare_record" "billing_origin" {
-  zone_id = var.cloudflare_zone_id
-  name    = var.billing_origin_host
-  content = replace(google_cloud_run_v2_service.billing_uat.uri, "https://", "")
-  type    = "CNAME"
-  ttl     = 60
-  proxied = false
+# 4. Billing is served by the core Edge Gateway Worker. The Worker proxies to
+# google_cloud_run_v2_service.billing_uat.uri; no Enterprise-only Origin Rule
+# or DNS-only origin alias is required.
+resource "cloudflare_workers_domain" "billing" {
+  account_id = var.cloudflare_account_id
+  zone_id    = var.cloudflare_zone_id
+  hostname   = var.billing_host
+  service    = var.edge_gateway_core_worker
 }

--- a/terraform-hcl-standard/modules/serverless_uat/outputs.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/outputs.tf
@@ -13,12 +13,12 @@ output "content_service_uri" {
   value       = google_cloud_run_v2_service.content_uat.uri
 }
 
-output "billing_origin_host" {
-  description = "DNS-only Cloudflare hostname used for the Billing origin override"
-  value       = cloudflare_record.billing_origin.name
+output "billing_host" {
+  description = "Billing custom domain owned by the core Edge Gateway Worker"
+  value       = cloudflare_workers_domain.billing.hostname
 }
 
-output "billing_origin_target" {
-  description = "Cloud Run hostname targeted by the Billing origin alias"
-  value       = cloudflare_record.billing_origin.content
+output "billing_worker_service" {
+  description = "Worker service attached to the Billing custom domain"
+  value       = cloudflare_workers_domain.billing.service
 }

--- a/terraform-hcl-standard/modules/serverless_uat/variables.tf
+++ b/terraform-hcl-standard/modules/serverless_uat/variables.tf
@@ -25,11 +25,22 @@ variable "supabase_pooler_url" {
 
 variable "cloudflare_zone_id" {
   type        = string
-  description = "Cloudflare zone ID containing the serverless Billing origin alias"
+  description = "Cloudflare zone ID containing the serverless Billing custom domain"
 }
 
-variable "billing_origin_host" {
+variable "cloudflare_account_id" {
   type        = string
-  description = "DNS-only same-zone hostname used by the Cloudflare Billing Origin Rule"
-  default     = "billing-origin-serverless-uat.onwalk.net"
+  description = "Cloudflare account ID owning the core Edge Gateway Worker"
+}
+
+variable "billing_host" {
+  type        = string
+  description = "Public Billing Worker custom domain"
+  default     = "billing-serverless-uat.onwalk.net"
+}
+
+variable "edge_gateway_core_worker" {
+  type        = string
+  description = "Core Edge Gateway Worker service that proxies Billing to Cloud Run"
+  default     = "edge-gateway-core-uat"
 }


### PR DESCRIPTION
## Outcome
Replace the Billing DNS-only origin alias with a Cloudflare Worker custom domain attached to edge-gateway-core.

## Issue
- https://github.com/ai-workspace-infra/platform-ops-toolkit/actions/runs/32198428682/job/95909479148

## Scope
- Manage cloudflare_workers_domain for the Billing public hostname.
- Add Cloudflare account, Billing host, and core Worker inputs.
- Replace origin-alias outputs and documentation.

## Verification
- HCL formatting was reviewed and git diff checks pass.
- Terraform validate is delegated to CI because Terraform is not installed in the local workspace.

## Risk / Security / Configuration
- Pins the Cloudflare provider to the compatible 4.52.x major range.
- The core Worker service must exist before applying the custom domain.

## Rollback
Revert this PR and import or restore the prior DNS record only if the legacy architecture is intentionally reinstated.

## Related
- https://registry.terraform.io/providers/cloudflare/cloudflare/4.52.7/docs/resources/workers_domain
- https://github.com/ai-workspace-services/edge-gateway/pull/new/bugfix/billing-custom-domain-proxy